### PR TITLE
feat: Khuzur table-wide sequential combat loop & dynamic deck fixes

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -133,34 +133,57 @@ export const GameBoard: React.FC = () => {
 
         {/* Opponents Flex Container */}
         <div className="flex flex-row overflow-x-auto md:flex-wrap md:justify-center gap-2 md:gap-4 z-10 pb-2 md:pb-0 custom-scrollbar">
-          {Array.from(gameState.players.entries()).filter(([id]) => id !== room.sessionId).map(([id, player]) => (
-            <div key={id} className={`bg-black/40 px-3 py-2 md:px-6 md:py-4 rounded-xl text-center flex flex-col items-center relative border shadow-lg min-w-[100px] md:min-w-0 md:sm:w-48 flex-shrink-0 ${gameState.phase === 'waiting' && player.isReady ? 'border-green-500' : 'border-white/10'}`}>
-              {gameState.currentTurn === id && (
-                <div className="absolute -top-3 bg-yellow-500 text-yellow-900 text-[9px] md:text-xs font-bold px-2 py-0.5 md:px-3 md:py-1 rounded-full shadow-md animate-pulse whitespace-nowrap">
-                  PLAYING
-                </div>
-              )}
-              {gameState.phase === 'waiting' && player.isReady && (
-                <div className="absolute -top-3 bg-green-500 text-green-900 text-[9px] md:text-xs font-bold px-2 py-0.5 md:px-3 md:py-1 rounded-full shadow-md whitespace-nowrap">
-                  READY
-                </div>
-              )}
-              {/* Team badge */}
-              {gameState.mode === 'teams' && (
-                <div className={`absolute -bottom-3 px-2 py-0.5 md:px-3 md:py-1 rounded-full text-[9px] md:text-[10px] font-extrabold shadow border whitespace-nowrap ${player.team === 0 ? 'bg-blue-700 text-blue-100 border-blue-300/30' : 'bg-red-700 text-red-100 border-red-300/30'}`}>
-                  {player.team === 0 ? 'BLUE' : 'RED'}
-                </div>
-              )}
+          {(() => {
+            const seatOrder = Array.from(gameState.seatOrder);
+            let opponents: { id: string, player: any }[] = [];
+            
+            if (seatOrder.length > 0) {
+              // Game started: order opponents circularly starting from the player to their left
+              const myIdx = seatOrder.indexOf(room.sessionId);
+              if (myIdx !== -1) {
+                for (let i = 1; i < seatOrder.length; i++) {
+                  const oppId = seatOrder[(myIdx + i) % seatOrder.length];
+                  const oppPlayer = gameState.players.get(oppId);
+                  if (oppPlayer) opponents.push({ id: oppId, player: oppPlayer });
+                }
+              }
+            } else {
+              // Waiting phase: Just list other players, maybe sorted by team
+              opponents = Array.from(gameState.players.entries())
+                .filter(([id]) => id !== room.sessionId)
+                .map(([id, player]) => ({ id, player }))
+                .sort((a, b) => (a.player.team || 0) - (b.player.team || 0));
+            }
 
-              <div className="text-xs md:text-sm text-gray-200 font-mono mb-2 md:mb-3 bg-green-900/40 border border-green-700/50 px-2 py-1 md:px-3 md:py-1.5 rounded truncate w-full">
-                 {id.slice(0, 5)}...
+            return opponents.map(({ id, player }) => (
+              <div key={id} className={`bg-black/40 px-3 py-2 md:px-6 md:py-4 rounded-xl text-center flex flex-col items-center relative border shadow-lg min-w-[100px] md:min-w-0 md:sm:w-48 flex-shrink-0 ${gameState.phase === 'waiting' && player.isReady ? 'border-green-500' : 'border-white/10'}`}>
+                {gameState.currentTurn === id && (
+                  <div className="absolute -top-3 bg-yellow-500 text-yellow-900 text-[9px] md:text-xs font-bold px-2 py-0.5 md:px-3 md:py-1 rounded-full shadow-md animate-pulse whitespace-nowrap">
+                    PLAYING
+                  </div>
+                )}
+                {gameState.phase === 'waiting' && player.isReady && (
+                  <div className="absolute -top-3 bg-green-500 text-green-900 text-[9px] md:text-xs font-bold px-2 py-0.5 md:px-3 md:py-1 rounded-full shadow-md whitespace-nowrap">
+                    READY
+                  </div>
+                )}
+                {/* Team badge */}
+                {gameState.mode === 'teams' && (
+                  <div className={`absolute -bottom-3 px-2 py-0.5 md:px-3 md:py-1 rounded-full text-[9px] md:text-[10px] font-extrabold shadow border whitespace-nowrap ${player.team === 0 ? 'bg-blue-700 text-blue-100 border-blue-300/30' : 'bg-red-700 text-red-100 border-red-300/30'}`}>
+                    {player.team === 0 ? 'BLUE' : 'RED'}
+                  </div>
+                )}
+
+                <div className="text-xs md:text-sm text-gray-200 font-mono mb-2 md:mb-3 bg-green-900/40 border border-green-700/50 px-2 py-1 md:px-3 md:py-1.5 rounded truncate w-full">
+                   {id.slice(0, 5)}...
+                </div>
+                <div className="mt-1 md:mt-2 text-lg md:text-xl font-bold text-white flex items-center space-x-1 md:space-x-2 bg-black/30 px-3 py-1.5 md:px-4 md:py-2 rounded-lg leading-none">
+                  <span className="text-xl md:text-2xl -mt-1 md:-mt-1">🃏</span>
+                  <span>{player.hand.length}</span>
+                </div>
               </div>
-              <div className="mt-1 md:mt-2 text-lg md:text-xl font-bold text-white flex items-center space-x-1 md:space-x-2 bg-black/30 px-3 py-1.5 md:px-4 md:py-2 rounded-lg leading-none">
-                <span className="text-xl md:text-2xl -mt-1 md:-mt-1">🃏</span>
-                <span>{player.hand.length}</span>
-              </div>
-            </div>
-          ))}
+            ));
+          })()}
         </div>
       </div>
 

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -82,10 +82,6 @@ export const GameBoard: React.FC = () => {
     room.send("pickUp");
   };
 
-  const handlePass = () => {
-    room.send("pass");
-  };
-
   const handleTeamSelect = (teamId: number) => {
     room.send("switchTeam", { team: teamId });
   };
@@ -368,11 +364,6 @@ export const GameBoard: React.FC = () => {
                 <button onClick={handleAttack} disabled={selectedCards.length === 0} className="px-6 py-2 md:px-8 md:py-3 bg-red-600 hover:bg-red-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-full font-bold shadow-lg transition active:scale-95 text-xs md:text-base">
                    Attack ({selectedCards.length})
                 </button>
-                {tableCards.length > 0 && (
-                   <button onClick={handlePass} className="px-6 py-2 md:px-8 md:py-3 bg-blue-600 hover:bg-blue-500 rounded-full font-bold shadow-lg transition active:scale-95 text-xs md:text-base">
-                      Pass
-                   </button>
-                )}
              </>
            )}
            {isMyTurn && gameState.phase === 'playing' && attackCards.length > 0 && (

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useGame } from '../contexts/GameContext';
 import { Card as UICard } from './Card';
-import { Card as SharedCard } from '@durak/shared';
+import { Card as SharedCard, Player } from '@durak/shared';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAudio } from '../utils/audio';
 
@@ -131,7 +131,7 @@ export const GameBoard: React.FC = () => {
         <div className="flex flex-row overflow-x-auto md:flex-wrap md:justify-center gap-2 md:gap-4 z-10 pb-2 md:pb-0 custom-scrollbar">
           {(() => {
             const seatOrder = Array.from(gameState.seatOrder);
-            let opponents: { id: string, player: any }[] = [];
+            let opponents: { id: string, player: Player }[] = [];
             
             if (seatOrder.length > 0) {
               // Game started: order opponents circularly starting from the player to their left

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -143,6 +143,7 @@ export const GameBoard: React.FC = () => {
               if (myIdx !== -1) {
                 for (let i = 1; i < seatOrder.length; i++) {
                   const oppId = seatOrder[(myIdx + i) % seatOrder.length];
+                  if (!oppId) continue;
                   const oppPlayer = gameState.players.get(oppId);
                   if (oppPlayer) opponents.push({ id: oppId, player: oppPlayer });
                 }

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -273,38 +273,43 @@ export class DurakRoom extends Room<GameState> {
       return;
     }
 
-    // Success! Move defenders from hand to table history paired with attack cards.
-    // To ensure they are displayed with the attacked card underneath, 
-    // we push the Attack Card first, then the Defending Card.
-    for (let i = 0; i < defendingCards.length; i++) {
-      const defCard = defendingCards[i];
+    // Success! The cards they just defended against become table history.
+    atkCards.forEach(c => {
+      this.state.table.push(new Card(c.suit, c.rank, c.isJoker));
+    });
+
+    // The player's new defending cards become the NEW activeAttackCards
+    this.state.activeAttackCards.splice(0, this.state.activeAttackCards.length);
+
+    defendingCards.forEach(defCard => {
       const idx = player.hand.findIndex((hc) => hc.suit === defCard.suit && hc.rank === defCard.rank);
       if (idx !== -1) {
         player.hand.splice(idx, 1);
-
-        // Colyseus arrays shouldn't share references directly across state structures
-        const originalAtk = atkCards[i];
-        const clonedAtk = new Card(originalAtk.suit, originalAtk.rank, originalAtk.isJoker);
-
-        this.state.table.push(clonedAtk); // Attack card on bottom
-        this.state.table.push(defCard);     // Defense card on top
+        this.state.activeAttackCards.push(new Card(defCard.suit, defCard.rank, defCard.isJoker));
       }
-    }
-
-    // Since we pushed active attacks as clones, clear the originals fully by splicing
-    this.state.activeAttackCards.splice(0, this.state.activeAttackCards.length);
+    });
 
     // Increment chain
     this.state.defenseChainCount++;
 
-    // Since 'pass' logic is removed, a successful defense immediately ends the round
-    // and clears the table.
-    DurakEngine.endRound(this.state, null);
-    DurakEngine.replenishAll(this.state);
-    this.checkGameOver();
+    if (this.state.defenseChainCount >= this.state.players.size - 1) {
+      // Everyone in the circle successfully defended!
+      DurakEngine.endRound(this.state, null);
+      DurakEngine.replenishAll(this.state);
+      this.checkGameOver();
 
-    // Because this is the defender's turn (they just played their card), keeping the turn on them
-    // means they become the next attacker! We do not pass it back to the previous attacker.
+      // The next trick is led by the player who made the FIRST defense in this chain.
+      // E.g., if P1 attacked, P2 was first defender.
+      const ids = Array.from(this.state.seatOrder);
+      const currentIdx = ids.indexOf(client.sessionId);
+      const firstDefenderIdx = (currentIdx - (this.state.defenseChainCount - 1) + ids.length * 10) % ids.length;
+      if (ids[firstDefenderIdx]) {
+        this.state.currentTurn = ids[firstDefenderIdx];
+      }
+    } else {
+      // The circle continues! The next player must now beat the cards just played.
+      this.nextTurn();
+    }
   
 
 

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -113,9 +113,6 @@ export class DurakRoom extends Room<GameState> {
         }
       }
     });
-
-    // Add pass action for attacker
-    this.onMessage("pass", (client) => this.handlePass(client));
   }
 
   onJoin(client: Client, options: any) {
@@ -300,38 +297,16 @@ export class DurakRoom extends Room<GameState> {
     // Increment chain
     this.state.defenseChainCount++;
 
-    if (this.state.defenseChainCount >= this.state.players.size - 1) {
-      // Everyone defended! Round is dead.
-      DurakEngine.endRound(this.state, null);
-      DurakEngine.replenishAll(this.state);
-      this.checkGameOver();
-
-      // Because this is the defender's turn (they just played their card), passing it to nextTurn
-      // would skip them! But since they successfully beat all attacks, they should be the next attacker!
-      // But wait! `handleAttack` passes the turn to the defender immediately. So right now, currentTurn is the defender!
-      // We don't want to skip them, so we just keep the turn on them so they can attack!
-    } else {
-      // Allow the attacker to throw in more cards instead of forcing the defender's defense to be a new attack.
-      this.state.currentTurn = this.getPreviousTurn(client.sessionId);
-
-      // We don't draw yet (drawing happens at endRound). 
-      this.checkGameOver(); 
-    }
-  }
-  
-  private handlePass(client: Client) {
-    // Only the current attacker can optionally pass to the next attacker
-    if (this.state.currentTurn !== client.sessionId) return;
-    
-    // If there is an active defense on the table but current attacker passes adding more cards,
-    // we would end the attack phase.
+    // Since 'pass' logic is removed, a successful defense immediately ends the round
+    // and clears the table.
     DurakEngine.endRound(this.state, null);
     DurakEngine.replenishAll(this.state);
     this.checkGameOver();
-    
-    // Next player starts fresh
-    this.nextTurn();
-  }
+
+    // Because this is the defender's turn (they just played their card), keeping the turn on them
+    // means they become the next attacker! We do not pass it back to the previous attacker.
+  
+
 
   private handlePickUp(client: Client) {
     if (this.state.currentTurn !== client.sessionId) return;

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -21,7 +21,7 @@ export class DurakRoom extends Room<GameState> {
     if (options.teamSelection) {
       this.state.teamSelection = String(options.teamSelection);
     }
-    
+
     if (options.handSize) {
       this.state.targetHandSize = parseInt(options.handSize, 10);
     }
@@ -298,24 +298,18 @@ export class DurakRoom extends Room<GameState> {
       DurakEngine.replenishAll(this.state);
       this.checkGameOver();
 
-      // The next trick is led by the player who made the FIRST defense in this chain.
-      // E.g., if P1 attacked, P2 was first defender.
-      const ids = Array.from(this.state.seatOrder);
-      const currentIdx = ids.indexOf(client.sessionId);
-      const firstDefenderIdx = (currentIdx - (this.state.defenseChainCount - 1) + ids.length * 10) % ids.length;
-      if (ids[firstDefenderIdx]) {
-        this.state.currentTurn = ids[firstDefenderIdx];
-      }
+      // The next trick is led by the player who made the LAST defense in this chain.
+      // Since currentTurn is already the client who just defended, we simply leave it alone!
     } else {
       // The circle continues! The next player must now beat the cards just played.
       this.nextTurn();
     }
-  
+  }
 
 
   private handlePickUp(client: Client) {
     if (this.state.currentTurn !== client.sessionId) return;
-    
+
     // Use engine to handle pickup logic
     DurakEngine.endRound(this.state, client.sessionId);
     DurakEngine.replenishAll(this.state);
@@ -326,11 +320,11 @@ export class DurakRoom extends Room<GameState> {
   }
 
   private handleSwapHuzur(client: Client) {
-     const player = this.state.players.get(client.sessionId)!;
-     const success = DurakEngine.swapHuzur(player, this.state);
-     if (!success) {
-       client.send("error", "Cannot swap Huzur. You need the 7 of trump, and the deck cannot be empty.");
-     }
+    const player = this.state.players.get(client.sessionId)!;
+    const success = DurakEngine.swapHuzur(player, this.state);
+    if (!success) {
+      client.send("error", "Cannot swap Huzur. You need the 7 of trump, and the deck cannot be empty.");
+    }
   }
 
   private checkGameOver() {
@@ -342,7 +336,7 @@ export class DurakRoom extends Room<GameState> {
     this.state.players.forEach((player, id) => {
       // check if player already in winners list
       const alreadyWon = this.state.winners.includes(id);
-      
+
       if (this.state.deck.length === 0 && player.hand.length === 0 && !alreadyWon) {
         this.state.winners.push(id);
         hasNewWinner = true;

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -222,7 +222,7 @@ export class DurakEngine {
    */
   static replenishAll(state: GameState): void {
     state.players.forEach(player => {
-      const amount = DurakEngine.computeDrawAmount(player, state.deck.length);
+      const amount = DurakEngine.computeDrawAmount(player, state.deck.length, state.targetHandSize);
       for (let i = 0; i < amount; i++) {
         const card = state.deck.pop();
         if (card) player.hand.push(new Card(card.suit, card.rank, card.isJoker));

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -311,16 +311,5 @@ export class DurakEngine {
     state.defenseChainCount = 0;
   }
 
-  /**
-   * Helper to draw cards for all players at the end of a round.
-   */
-  static replenishAll(state: GameState): void {
-    state.players.forEach(player => {
-      const amount = DurakEngine.computeDrawAmount(player, state.deck.length, state.targetHandSize);
-      for (let i = 0; i < amount; i++) {
-        const card = state.deck.pop();
-        if (card) player.hand.push(new Card(card.suit, card.rank, card.isJoker));
-      }
-    });
-  }
+
 }


### PR DESCRIPTION
This PR introduces a significant overhaul of the combat loop mechanics to support the sequential Khuzur variant properly, along with several UI and responsive design polishes for the Discord Activity environment.

### Changes:
- **Sequential Defense Loop (Khuzur Variant):** The table structure now supports a clockwise turn sequence where defenses become the new table target for the next player rather than dropping back to the original attacker.
- **Round Completion:** Removed manual 'Pass' mechanics. A round immediately ends when the cascade mathematically satisfies all players, handing initiative seamlessly to the last acting defender.
- **Dynamic Replenish Tracker:** Engine specifically fetches `targetHandSize` during replenishment correctly to accommodate dynamic lobby configs (e.g. 7-card vs 5-card rules).
- **GameBoard Opponent Display:** Client UI automatically parses the server `seatOrder` array to circularly visually align opponent clients relative to the player, enforcing fair team spacing (BRBR/BRBRBR).
- **Responsive Overhaul:** Converted Board UI constraints to 100dvh for Discord Mobile clients.