### PR TITLE
fix(#112): prevent swap of picked-up trump 7 in all cases

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -43,7 +43,7 @@ export const GameBoard: React.FC = () => {
     return () => clearInterval(interval);
   }, [gameState]);
 
-  // Issue #80: Re-render every 250ms so defense visibility expires precisely at 10s.
+  // Issue #80: drive time-based visibility without calling Date.now() during render
   const [now, setNow] = React.useState(() => Date.now());
   React.useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 250);
@@ -550,15 +550,19 @@ export const GameBoard: React.FC = () => {
              </>
            )}
            {gameState.phase === 'playing' && (gameState.deck?.length || 0) > 0 && gameState.huzurCard && (
-             (gameState.huzurCard.isJoker && myHand.some(c => c.suit === 'Spades' && c.rank === 14)) ? (
-               <button onClick={handleSwapHuzur} className="px-6 py-2 md:px-8 md:py-3 mx-4 bg-purple-600 hover:bg-purple-500 rounded-full font-bold shadow-lg transition active:scale-95 text-xs md:text-base">
-                 Swap Ace
-               </button>
-             ) : (!gameState.huzurCard.isJoker && myHand.some(c => c.suit === gameState.huzurSuit && c.rank === 7)) ? (
-               <button onClick={handleSwapHuzur} className="px-6 py-2 md:px-8 md:py-3 mx-4 bg-purple-600 hover:bg-purple-500 rounded-full font-bold shadow-lg transition active:scale-95 text-xs md:text-base">
-                 Swap 7
-               </button>
-             ) : null
+             gameState.huzurCard.isJoker ? (
+               myHand.some(c => c.suit === 'Spades' && c.rank === 16) && !myPlayer?.pickedUpCardKeys.includes('Spades:16:0') ? (
+                 <button onClick={handleSwapHuzur} className="px-6 py-2 md:px-8 md:py-3 mx-4 bg-purple-600 hover:bg-purple-500 rounded-full font-bold shadow-lg transition active:scale-95 text-xs md:text-base">
+                   Swap Ace
+                 </button>
+               ) : null
+             ) : (
+               myHand.some(c => c.suit === gameState.huzurSuit && c.rank === 7) && !myPlayer?.pickedUpCardKeys.includes(`${gameState.huzurSuit}:7:0`) ? (
+                 <button onClick={handleSwapHuzur} className="px-6 py-2 md:px-8 md:py-3 mx-4 bg-purple-600 hover:bg-purple-500 rounded-full font-bold shadow-lg transition active:scale-95 text-xs md:text-base">
+                   Swap 7
+                 </button>
+               ) : null
+             )
            )}
          </div>
 

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -45,11 +45,18 @@ export const useGame = () => useContext(GameContext);
 
 export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const defaultServerUrl = useMemo(() => {
-    // In dev we rely on Vite's proxy so the backend port can change (2567/2568/etc)
-    // without changing the client code.
     if (typeof window === 'undefined') return 'ws://localhost:2567';
+
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${wsProtocol}//${window.location.host}/api-ws`;
+
+    // Vite dev server runs on 5173 and proxies /api-ws to Colyseus.
+    if (window.location.port === '5173') {
+      return `${wsProtocol}//${window.location.host}/api-ws`;
+    }
+
+    // When the app is served by the server container itself (Docker / production),
+    // connect directly to the same origin instead of going through the Vite proxy.
+    return `${wsProtocol}//${window.location.host}`;
   }, []);
 
   // Prefer explicit env var if provided, otherwise use same-origin + Vite proxy

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -5,16 +5,19 @@ WORKDIR /usr/src/app
 # Copy root package.json and lockfile
 COPY package*.json ./
 
-# Copy packages package.json files so npm install can resolve workspaces
+# Copy packages package.json files so npm ci can resolve all workspaces
 COPY packages/server/package.json ./packages/server/
 COPY packages/client/package.json ./packages/client/
 COPY packages/shared/package.json ./packages/shared/
 
-# Install dependencies only for the server and shared workspaces
-RUN npm ci --workspace packages/shared --workspace packages/server --include-workspace-root=false
+# Install all workspace dependencies, including client build tooling
+RUN npm ci
 
 # Copy the rest of the monorepo code
 COPY . .
+
+# Build the client so the server can serve the production UI from /packages/client/dist
+RUN npm run build:client
 
 # Expose colyseus port
 EXPOSE 2567

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -266,14 +266,12 @@ export class DurakEngine {
 
     // New restriction (#76): if the swap card was obtained by picking up cards from another player,
     // disallow swapping it with the bottom trump card.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const anyPlayer = player as any;
-    const pickedUpKeys = (anyPlayer.__lastPickedUpCardKeys as Set<string> | undefined);
-    
+    const pickedUpKeys = player.pickedUpCardKeys;
+
     if (isJokerTrump) {
-      if (pickedUpKeys && pickedUpKeys.has(`Spades:${Rank.Ace}:0`)) return false;
+      if (pickedUpKeys.includes(`Spades:${Rank.Ace}:0`)) return false;
     } else {
-      if (pickedUpKeys && pickedUpKeys.has(`${state.huzurSuit}:${Rank.Seven}:0`)) return false;
+      if (pickedUpKeys.includes(`${state.huzurSuit}:${Rank.Seven}:0`)) return false;
     }
 
     const playerSeven = player.hand[handIndex]!;
@@ -314,6 +312,10 @@ export class DurakEngine {
    * Resets the round state. Clears table if successful, or hands cards to player if they pick up.
    */
   static endRound(state: GameState, pickerUpperId: string | null): void {
+    // IMPORTANT: copy cards out before clearing so we don't accidentally lose them.
+    const tableCards = Array.from(state.table).filter((c): c is Card => c !== undefined);
+    const activeCards = Array.from(state.activeAttackCards).filter((c): c is Card => c !== undefined);
+
     if (pickerUpperId) {
       // Player picked up the whole table
       const player = state.players.get(pickerUpperId);
@@ -322,35 +324,50 @@ export class DurakEngine {
         player.lastDrawLog.splice(0, player.lastDrawLog.length);
 
         // Track the exact cards picked up in THIS pickup event.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const anyPlayer = player as any;
-        const pickedUp = new Set<string>();
         const collectedKeys = new Set<string>();
         const collectCard = (card: Card) => {
           const key = `${card.suit}:${card.rank}:${card.isJoker ? 1 : 0}`;
           if (collectedKeys.has(key)) return;
 
           collectedKeys.add(key);
-          player.hand.push(new Card(card.suit, card.rank, card.isJoker));
-          pickedUp.add(key);
+          const cloned = new Card(card.suit, card.rank, card.isJoker);
+          player.hand.push(cloned);
+          player.pickedUpCardKeys.push(key);
           player.lastDrawLog.push(`+${card.rank}${card.suit[0].toLowerCase()}${card.isJoker ? '(J)' : ''}`);
         };
 
-        state.table.forEach(collectCard);
-        state.activeAttackCards.forEach(collectCard);
+        player.pickedUpCardKeys.clear();
 
-        anyPlayer.__lastPickedUpCardKeys = pickedUp;
+        tableCards.forEach(collectCard);
+        activeCards.forEach(collectCard);
+
         player.hasPickedUp = true;
       }
     } else {
       // Success! Cards are dead.
-      state.table.forEach(card => state.discardPile.push(new Card(card.suit, card.rank, card.isJoker)));
-      state.activeAttackCards.forEach(card => state.discardPile.push(new Card(card.suit, card.rank, card.isJoker)));
+      tableCards.forEach((card) => state.discardPile.push(new Card(card.suit, card.rank, card.isJoker)));
+      activeCards.forEach((card) => state.discardPile.push(new Card(card.suit, card.rank, card.isJoker)));
 
-      // Clear last pickup tracking since no pickup happened.
-      state.players.forEach(p => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (p as any).__lastPickedUpCardKeys = undefined;
+      // Clear pickup tracking only for cards that are no longer in hand.
+      // Cards that were picked up permanently cannot be swapped, so we keep their keys.
+      state.players.forEach((p) => {
+        const currentHandKeys = new Set<string>();
+        for (const card of p.hand) {
+          currentHandKeys.add(`${card.suit}:${card.rank}:${card.isJoker ? 1 : 0}`);
+        }
+
+        // Remove keys for cards that are no longer in this player's hand
+        const keysToRemove: string[] = [];
+        for (let i = 0; i < p.pickedUpCardKeys.length; i++) {
+          const key = p.pickedUpCardKeys[i];
+          if (!currentHandKeys.has(key)) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((key) => {
+          const idx = p.pickedUpCardKeys.indexOf(key);
+          if (idx >= 0) p.pickedUpCardKeys.splice(idx, 1);
+        });
       });
     }
 

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -3,6 +3,20 @@ import { Player } from "../state/Player";
 import { GameState } from "../state/GameState";
 
 export class DurakEngine {
+  private static syncPickedUpKeysWithHand(player: Player): void {
+    const currentHandKeys = new Set<string>();
+    for (const card of player.hand) {
+      currentHandKeys.add(`${card.suit}:${card.rank}:${card.isJoker ? 1 : 0}`);
+    }
+
+    for (let i = player.pickedUpCardKeys.length - 1; i >= 0; i--) {
+      const key = player.pickedUpCardKeys[i];
+      if (!key || !currentHandKeys.has(key)) {
+        player.pickedUpCardKeys.splice(i, 1);
+      }
+    }
+  }
+
   /**
    * Initializes a new Durak game given a GameState, player IDs, and hand size.
    */
@@ -323,6 +337,9 @@ export class DurakEngine {
         // Clear previous draw log
         player.lastDrawLog.splice(0, player.lastDrawLog.length);
 
+        // Keep existing tracked pickup restrictions for cards still in hand.
+        DurakEngine.syncPickedUpKeysWithHand(player);
+
         // Track the exact cards picked up in THIS pickup event.
         const collectedKeys = new Set<string>();
         const collectCard = (card: Card) => {
@@ -332,12 +349,11 @@ export class DurakEngine {
           collectedKeys.add(key);
           const cloned = new Card(card.suit, card.rank, card.isJoker);
           player.hand.push(cloned);
-          player.pickedUpCardKeys.push(key);
+          if (!player.pickedUpCardKeys.includes(key)) {
+            player.pickedUpCardKeys.push(key);
+          }
           player.lastDrawLog.push(`+${card.rank}${card.suit[0].toLowerCase()}${card.isJoker ? '(J)' : ''}`);
         };
-
-        player.pickedUpCardKeys.clear();
-
         tableCards.forEach(collectCard);
         activeCards.forEach(collectCard);
 
@@ -351,23 +367,7 @@ export class DurakEngine {
       // Clear pickup tracking only for cards that are no longer in hand.
       // Cards that were picked up permanently cannot be swapped, so we keep their keys.
       state.players.forEach((p) => {
-        const currentHandKeys = new Set<string>();
-        for (const card of p.hand) {
-          currentHandKeys.add(`${card.suit}:${card.rank}:${card.isJoker ? 1 : 0}`);
-        }
-
-        // Remove keys for cards that are no longer in this player's hand
-        const keysToRemove: string[] = [];
-        for (let i = 0; i < p.pickedUpCardKeys.length; i++) {
-          const key = p.pickedUpCardKeys[i];
-          if (!currentHandKeys.has(key)) {
-            keysToRemove.push(key);
-          }
-        }
-        keysToRemove.forEach((key) => {
-          const idx = p.pickedUpCardKeys.indexOf(key);
-          if (idx >= 0) p.pickedUpCardKeys.splice(idx, 1);
-        });
+        DurakEngine.syncPickedUpKeysWithHand(p);
       });
     }
 

--- a/packages/shared/src/state/Player.ts
+++ b/packages/shared/src/state/Player.ts
@@ -4,6 +4,7 @@ import { Card } from "./Card";
 export class Player extends Schema {
   @type("string") id: string = "";
   @type([ Card ]) hand = new ArraySchema<Card>();
+  @type([ "string" ]) pickedUpCardKeys = new ArraySchema<string>();
   @type("boolean") hasPickedUp: boolean = false;
   @type("number") team: number = 0; // 0 or 1 for 3v3
   @type("boolean") isReady: boolean = false;

--- a/packages/shared/tests/DurakEngine.test.ts
+++ b/packages/shared/tests/DurakEngine.test.ts
@@ -263,7 +263,7 @@ describe('DurakEngine - Custom Rules', () => {
       p1.hand.push(...[sevenOfHearts]);
 
       // Simulate: the 7-of-trump came from a pickup event.
-      (p1 as any).__lastPickedUpCardKeys = new Set([`${Suit.Hearts}:${Rank.Seven}:0`]);
+      p1.pickedUpCardKeys.push(`${Suit.Hearts}:${Rank.Seven}:0`);
 
       const faceUpHuzur = new Card(Suit.Hearts, Rank.Ace);
       const fakeState = { huzurSuit: Suit.Hearts, huzurCard: faceUpHuzur, deck: { length: 10 } } as any;

--- a/packages/shared/tests/DurakEngine.test.ts
+++ b/packages/shared/tests/DurakEngine.test.ts
@@ -272,6 +272,40 @@ describe('DurakEngine - Custom Rules', () => {
       expect(success).toBe(false);
     });
 
+    test('swapHuzur - Remains disallowed after later pickup/round transitions while picked-up 7 is still in hand', () => {
+      const state = new GameState();
+      const p1 = new Player("p1");
+      const p2 = new Player("p2");
+      state.players.set(p1.id, p1);
+      state.players.set(p2.id, p2);
+
+      state.huzurSuit = Suit.Hearts;
+      state.huzurCard.suit = Suit.Hearts;
+      state.huzurCard.rank = Rank.Ace;
+      state.huzurCard.isJoker = false;
+      state.deck.push(new Card(Suit.Hearts, Rank.Ace, false));
+
+      // p1 initially picks up trump 7 from table.
+      state.table.push(new Card(Suit.Hearts, Rank.Seven, false));
+      DurakEngine.endRound(state, p1.id);
+      expect(p1.pickedUpCardKeys.includes(`${Suit.Hearts}:${Rank.Seven}:0`)).toBe(true);
+
+      // p1 later plays another card (not the 7), and a success round happens.
+      p1.hand.push(new Card(Suit.Clubs, Rank.Nine, false));
+      const nonTrumpIndex = p1.hand.findIndex((c) => c.suit === Suit.Clubs && c.rank === Rank.Nine);
+      expect(nonTrumpIndex).toBeGreaterThanOrEqual(0);
+      p1.hand.splice(nonTrumpIndex, 1);
+      DurakEngine.endRound(state, null);
+
+      // p1 also has another pickup event; previously this would clear old tracked keys.
+      state.table.push(new Card(Suit.Spades, Rank.Ten, false));
+      DurakEngine.endRound(state, p1.id);
+
+      // As long as p1 still holds the picked-up trump 7, swap must be blocked.
+      const canSwap = DurakEngine.swapHuzur(p1, state);
+      expect(canSwap).toBe(false);
+    });
+
     test('swapHuzur - Fails if deck is empty', () => {
       const p1 = new Player("p1");
       p1.hand.push(...[new Card(Suit.Hearts, Rank.Seven)]);


### PR DESCRIPTION
## Summary
- Enforce server-side restriction: a trump-7 (or joker-trump swap card) picked up from another player cannot be swapped with bottom trump while it remains in hand
- Preserve picked-up key tracking across round transitions and later pickup events
- Keep tracking cleaned only when the card leaves hand

## Tests
- Added regression test for flow: pick up trump 7 -> attack with different card -> later turn -> swap still blocked
- Shared tests pass locally

Closes #112