### PR TITLE
Fix card duplication on pick up

### DIFF
--- a/GAME_RULES.md
+++ b/GAME_RULES.md
@@ -1,0 +1,75 @@
+# Durak Game Rules & Conventions (Source of Truth)
+
+> **AI Instruction:** This game uses a highly customized "Hot Potato" progression system with custom deck, mass-attack rules, and hand replenishment logic. NEVER assume standard Durak rules. ALWAYS read this file before modifying `DurakEngine.ts`, `GrandmasterBot.ts`, or any game logic. This is a SINGLE-PLAYER game mode variant with a 42-card deck and no fixed hand size.
+
+## 1. The Deck & Card Values
+* **Deck Size**: 42 cards.
+* **Suits**: Spades, Hearts, Diamonds, Clubs.
+* **Ranks (Low to High)**: 7, 8, 9, 10, J, Q, K, 3, 2, Ace (A=16). Notice that 3, 2, and Ace are the highest standard cards.
+* **Jokers**: 
+  * **Black Joker** (Value 17): Acts as a Spades trump.
+  * **Red Joker** (Value 18): The highest card in the game. Acts as a Hearts trump.
+
+## 2. Game Setup & Huzur (Trump)
+* **Target Hand Size**: Configurable at game creation (typically 5 or 7 cards). Players maintain this size throughout the game by drawing from the deck.
+* **Dealing**: Each player is dealt up to `targetHandSize` cards from the shuffled deck. The dealing order is: Player 1 gets 1 card, Player 2 gets 1 card, ..., Player N gets 1 card, then repeat until each player has `targetHandSize` cards.
+* **The Huzur**: The bottom card of the deck is turned face up. Its suit determines the trump suit (`huzurSuit`). This card stays in the deck.
+* **First Turn**: Each player draws a random card from a separate deck. The player that drew the highest card gets to go first. In Team mode, 1 player from each team draws a card and the winning team decides who goes first.
+* **Swapping the Huzur**:
+  * A player holding the **7 of the Trump suit** can swap it with the face-up Huzur.
+  * If the Huzur is a Joker, a player holding the **Ace of Spades** can swap it.
+  * *Restriction*: A player CANNOT swap using a card they acquired by "picking up" from the table in a previous round. They must have drawn it naturally from the deck (`hasPickedUp` flag blocks this).
+
+## 3. "Hot Potato" Turn Progression (Clockwise)
+This game operates in a continuous circle (clockwise direction):
+1. **Player A** initiates an attack (single card or mass attack). Turn passes to Player B (next player clockwise).
+2. **Player B** must defend against Player A's cards. If successful, Player B's defending cards become the *new* attack cards.
+3. Turn passes to **Player C** (next player clockwise), who must now beat Player B's defense cards.
+4. **Successful Round End**: This continues clockwise until it reaches the player on the **right** of the person who started the attack (i.e., the player immediately before the attacker in clockwise order). If that player successfully defeats the stack, they:
+   - Put the entire stack into the discard pile (`bita`)
+   - Start a brand new attack (single or mass)
+   * *Example (4 players, clockwise P1 → P2 → P3 → P4 → P1)*: 
+     * P1 attacks with 1 card
+     * P2 defends and P1's card becomes P2's new attack
+     * P3 defends and P2's card becomes P3's new attack
+     * P4 defends and P3's card becomes P4's new attack
+     * P4 is the player on the right of P1 (attacker). If P4 successfully defeats, the table is cleared and P4 starts the next attack.
+
+## 4. Attacking Types
+When initiating an attack, a player can play either a **Single Card** or a **Mass Attack**.
+* **Single Card**: Play exactly 1 card.
+* **Mass Attacks**: Must contain exactly N cards with at least floor(N/2) pairs of cards with the same rank.
+  * **3-Card Mass** (1 Pair + 1 Random card): 
+    * **Standard max while the deck is intact** (has cards remaining).
+    * **Always allowed if targetHandSize >= 3**.
+  * **5-Card Mass** (2 Pairs + 1 Random card):
+    * **In targetHandSize = 5 lobbies**: ONLY allowed if the deck is empty AND all defending players have >= 5 cards in hand.
+    * **In targetHandSize = 7 lobbies**: Always allowed (deck intact or empty).
+  * **7-Card Mass** (3 Pairs + 1 Random card):
+    * **In targetHandSize = 7 lobbies**: ONLY allowed if the deck is empty AND all defending players have >= 7 cards in hand.
+    * **Not applicable in targetHandSize = 5 lobbies**.
+  * **7+ Card Masses** are not defined in the current implementation.
+
+## 5. Defending Mechanics
+* To defend, a player must assign one card from their hand to beat each incoming active attacking card (`1-to-1` matching).
+* A card beats another if:
+  * It is a **Joker** (beats everything except a higher Joker; Red Joker beats Black Joker).
+  * It is of the **same suit** as the attacker's card and has a **higher rank**.
+  * It is a **trump** (Huzur suit) beating a non-trump card.
+
+## 6. Picking Up & Hand Replenishment
+* **Picking Up**: If a player cannot or chooses not to defend, they must pick up **ALL** cards on the table. The round ends. The turn passes to the **player sitting to their left** (the next player clockwise), who starts a brand new attack (single or mass).
+  * *Example (4 players, clockwise P1 → P2 → P3 → P4)*: 
+    * P1 attacks
+    * P2 defends
+    * P3 defends P2
+    * P4 cannot defeat P3 and picks up the whole stack (cards from P1, P2, and P3)
+    * P1 (sitting to the left of P4, clockwise) gets to start the next attack.
+  * **hasPickedUp Flag**: When a player picks up, they are marked with `hasPickedUp = true`.
+* **Hand Replenishment (Drawing)**:
+  * Players normally draw cards at the end of each attack/defense action to maintain their `targetHandSize`.
+  * **Special rule**: Once a player picks up (`hasPickedUp = true`), they stop drawing from the deck **until their hand falls below targetHandSize again**.
+  * When replenishing, the number of cards drawn is: `Math.min(deckSize, targetHandSize - player.hand.length)`.
+
+## 7. Winning & Escaping the Game
+* **Goal**: Reach 0 cards when the deck is empty.

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -393,19 +393,22 @@ export class DurakRoom extends Room<GameState> {
     });
 
 
-    // Success! Move pairs to tableStacks (for visual rendering) and table (for history)
+    // Move resolved attack cards to table (history) and push visual pairs to tableStacks.
+    // Defense cards do NOT go to table — they become the new activeAttackCards only.
     assignments.forEach(pair => {
+      // Visual pairing for UI
       this.state.tableStacks.push(new Card(pair.atk.suit, pair.atk.rank, pair.atk.isJoker));
       this.state.tableStacks.push(new Card(pair.def.suit, pair.def.rank, pair.def.isJoker));
-      
+      // Attack cards are now resolved history
       this.state.table.push(new Card(pair.atk.suit, pair.atk.rank, pair.atk.isJoker));
-      this.state.table.push(new Card(pair.def.suit, pair.def.rank, pair.def.isJoker));
     });
 
-    // The player's new defending cards become the NEW activeAttackCards
+    // Clear activeAttackCards (resolved above into table history)
     this.state.activeAttackCards.splice(0, this.state.activeAttackCards.length);
 
-    defendingCards.forEach(defCard => {
+    // The matched defense cards become the NEW activeAttackCards (next player must beat these)
+    assignments.forEach(pair => {
+      const defCard = pair.def;
       const idx = player.hand.findIndex((hc) => hc.suit === defCard.suit && hc.rank === defCard.rank);
       if (idx !== -1) {
         player.hand.splice(idx, 1);

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -340,15 +340,11 @@ export class DurakEngine {
         // Keep existing tracked pickup restrictions for cards still in hand.
         DurakEngine.syncPickedUpKeysWithHand(player);
 
-        // Track the exact cards picked up in THIS pickup event.
-        const collectedKeys = new Set<string>();
+        // Collect all cards from the table (resolved history) and activeAttackCards (pending)
         const collectCard = (card: Card) => {
-          const key = `${card.suit}:${card.rank}:${card.isJoker ? 1 : 0}`;
-          if (collectedKeys.has(key)) return;
-
-          collectedKeys.add(key);
           const cloned = new Card(card.suit, card.rank, card.isJoker);
           player.hand.push(cloned);
+          const key = `${card.suit}:${card.rank}:${card.isJoker ? 1 : 0}`;
           if (!player.pickedUpCardKeys.includes(key)) {
             player.pickedUpCardKeys.push(key);
           }

--- a/packages/shared/tests/CardConservation.test.ts
+++ b/packages/shared/tests/CardConservation.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DurakEngine } from '../src/engine/DurakEngine';
+import { Card, Suit, Rank } from '../src/state/Card';
+import { GameState } from '../src/state/GameState';
+import { Player } from '../src/state/Player';
+
+/**
+ * Reproduces the exact 4-player pickup duplication bug reported by user:
+ *
+ * dummy-dffut attacked: -8h, -9h, -9c      (3 cards to activeAttackCards)
+ * dummy-ysvb2 defended: -Kh, -16h, -10c    (3 cards)
+ * x77d1Atfl picked up                       (should get exactly 6 cards, got 9)
+ *
+ * The bug was that handleDefend pushed defense cards to BOTH table and
+ * activeAttackCards, causing endRound to double-collect them.
+ */
+describe('Card Conservation - No Duplication on Pickup', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = new GameState();
+    DurakEngine.initializeGame(state, ['p1', 'p2', 'p3', 'p4'], 5, 'classic');
+
+    // Clear all hands and deck for controlled testing
+    state.deck.splice(0, state.deck.length);
+    state.table.splice(0, state.table.length);
+    state.tableStacks.splice(0, state.tableStacks.length);
+    state.activeAttackCards.splice(0, state.activeAttackCards.length);
+    state.players.forEach(p => p.hand.splice(0, p.hand.length));
+
+    state.huzurSuit = Suit.Spades;
+  });
+
+  it('pickup after defend: no card duplication (4-player scenario)', () => {
+    // Simulate the state AFTER p3 (dffut) attacked and p4 (ysvb2) defended:
+    //
+    // After defend, the flow should be:
+    // - table (history) contains the attack cards: 8h, 9h, 9c
+    // - activeAttackCards contains the defense cards: Kh, 16h(=2h), 10c
+    // These are DISJOINT sets.
+
+    const atk1 = new Card(Suit.Hearts, Rank.Eight);
+    const atk2 = new Card(Suit.Hearts, Rank.Nine);
+    const atk3 = new Card(Suit.Clubs, Rank.Nine);
+
+    const def1 = new Card(Suit.Hearts, Rank.King);
+    const def2 = new Card(Suit.Hearts, Rank.Ace); // 16h = Ace in our rank system
+    const def3 = new Card(Suit.Clubs, Rank.Ten);
+
+    // Attack cards moved to table (resolved history)
+    state.table.push(atk1, atk2, atk3);
+
+    // Defense cards are the new activeAttackCards
+    state.activeAttackCards.push(def1, def2, def3);
+
+    // p1 picks up
+    const p1 = state.players.get('p1')!;
+    DurakEngine.endRound(state, 'p1');
+
+    // CRITICAL: p1 should have exactly 6 cards, not 9
+    expect(p1.hand).toHaveLength(6);
+
+    // Verify each card appears exactly once
+    const cardKeys = p1.hand.map(c => `${c.suit}:${c.rank}`);
+    const uniqueKeys = new Set(cardKeys);
+    // All 6 should be unique (since all 6 inputs were unique)
+    expect(uniqueKeys.size).toBe(6);
+
+    // Table and active should be cleared
+    expect(state.table).toHaveLength(0);
+    expect(state.activeAttackCards).toHaveLength(0);
+    expect(state.tableStacks).toHaveLength(0);
+  });
+
+  it('successful round end: all cards go to discard pile, no duplication', () => {
+    const atk1 = new Card(Suit.Hearts, Rank.Eight);
+    const atk2 = new Card(Suit.Clubs, Rank.Nine);
+    const def1 = new Card(Suit.Hearts, Rank.King);
+    const def2 = new Card(Suit.Clubs, Rank.Ten);
+
+    // Table has resolved history (attack cards)
+    state.table.push(atk1, atk2);
+    // Active has pending defense cards that will become discarded too
+    state.activeAttackCards.push(def1, def2);
+
+    DurakEngine.endRound(state, null);
+
+    expect(state.discardPile).toHaveLength(4);
+    expect(state.table).toHaveLength(0);
+    expect(state.activeAttackCards).toHaveLength(0);
+  });
+
+  it('card conservation invariant: total cards = 42 through attack-defend-pickup cycle', () => {
+    // Re-initialize with a real deck
+    state = new GameState();
+    DurakEngine.initializeGame(state, ['p1', 'p2'], 5, 'classic');
+    state.huzurSuit = Suit.Diamonds;
+
+    const countAllCards = () => {
+      let total = state.deck.length + state.discardPile.length;
+      total += state.table.length;
+      total += state.activeAttackCards.length;
+      state.players.forEach(p => total += p.hand.length);
+      return total;
+    };
+
+    // After initialization, total should be 42
+    expect(countAllCards()).toBe(42);
+
+    // Simulate p1 attacking with 1 card
+    const p1 = state.players.get('p1')!;
+    const atkCard = p1.hand[0];
+    p1.hand.splice(0, 1);
+    state.activeAttackCards.push(new Card(atkCard.suit, atkCard.rank, atkCard.isJoker));
+
+    expect(countAllCards()).toBe(42);
+
+    // Simulate p2 picking up
+    DurakEngine.endRound(state, 'p2');
+    expect(countAllCards()).toBe(42);
+
+    // Replenish
+    DurakEngine.replenishAll(state);
+    expect(countAllCards()).toBe(42);
+  });
+
+  it('defense cards correctly become activeAttackCards without duplication', () => {
+    // Simulate: p1 attacks with 3 cards, p2 defends with 3 matching cards
+    const p2 = state.players.get('p2')!;
+
+    // Set up attack cards (pending defense)
+    const atk1 = new Card(Suit.Hearts, Rank.Eight);
+    const atk2 = new Card(Suit.Spades, Rank.Nine);
+    const atk3 = new Card(Suit.Clubs, Rank.Seven);
+    state.activeAttackCards.push(atk1, atk2, atk3);
+
+    // Give p2 cards that can beat the attacks
+    const def1 = new Card(Suit.Hearts, Rank.King);   // beats 8h
+    const def2 = new Card(Suit.Spades, Rank.Ten);    // beats 9s
+    const def3 = new Card(Suit.Clubs, Rank.Queen);   // beats 7c
+    p2.hand.push(def1, def2, def3);
+
+    // Find the assignment
+    const assignments = DurakEngine.findDefenseAssignment(
+      [def1, def2, def3],
+      [atk1, atk2, atk3],
+      state.huzurSuit
+    );
+    expect(assignments).not.toBeNull();
+    expect(assignments).toHaveLength(3);
+
+    // Simulate what handleDefend does AFTER the fix:
+    // 1. Move attack cards to table (history) + tableStacks (visual)
+    assignments!.forEach(pair => {
+      state.tableStacks.push(new Card(pair.atk.suit, pair.atk.rank, pair.atk.isJoker));
+      state.tableStacks.push(new Card(pair.def.suit, pair.def.rank, pair.def.isJoker));
+      state.table.push(new Card(pair.atk.suit, pair.atk.rank, pair.atk.isJoker));
+    });
+
+    // 2. Clear active attack cards
+    state.activeAttackCards.splice(0, state.activeAttackCards.length);
+
+    // 3. Defense cards become new active attacks
+    assignments!.forEach(pair => {
+      const defCard = pair.def;
+      const idx = p2.hand.findIndex(hc => hc.suit === defCard.suit && hc.rank === defCard.rank);
+      if (idx !== -1) {
+        p2.hand.splice(idx, 1);
+        state.activeAttackCards.push(new Card(defCard.suit, defCard.rank, defCard.isJoker));
+      }
+    });
+
+    // Verify: table has 3 attack cards (history), active has 3 defense cards
+    expect(state.table).toHaveLength(3);
+    expect(state.activeAttackCards).toHaveLength(3);
+    expect(p2.hand).toHaveLength(0);
+
+    // Verify NO overlap between table and activeAttackCards
+    const tableKeys = new Set(Array.from(state.table).map(c => `${c.suit}:${c.rank}`));
+    const activeKeys = new Set(Array.from(state.activeAttackCards).map(c => `${c.suit}:${c.rank}`));
+    
+    for (const key of activeKeys) {
+      expect(tableKeys.has(key)).toBe(false);
+    }
+
+    // Now if p3 picks up, they should get exactly 6 cards
+    const p3 = state.players.get('p3')!;
+    DurakEngine.endRound(state, 'p3');
+    expect(p3.hand).toHaveLength(6);
+  });
+});

--- a/packages/shared/tests/Stacking.test.ts
+++ b/packages/shared/tests/Stacking.test.ts
@@ -48,25 +48,29 @@ describe('DurakEngine - Stacking and Round End', () => {
     expect(player.lastDrawLog.length).toBeGreaterThan(0);
   });
 
-  test('endRound - does not duplicate cards that appear in both table and active attacks', () => {
+  test('endRound - collects all cards from disjoint table and activeAttackCards on pickup', () => {
     const state = new GameState();
     const player = new Player();
     player.id = 'player1';
     state.players.set(player.id, player);
 
-    const sharedCard = new Card(Suit.Hearts, Rank.Nine);
-    const tableCard = new Card(Suit.Spades, Rank.Eight);
+    // After the fix, table = resolved history, activeAttackCards = pending defense.
+    // These sets are always disjoint.
+    const historyCard = new Card(Suit.Spades, Rank.Eight);     // resolved attack
+    const pendingAtk = new Card(Suit.Hearts, Rank.Nine);       // pending attack
+    const pendingAtk2 = new Card(Suit.Clubs, Rank.Ten);        // another pending attack
 
-    state.table.push(tableCard);
-    state.table.push(sharedCard);
-    state.activeAttackCards.push(sharedCard);
+    state.table.push(historyCard);
+    state.activeAttackCards.push(pendingAtk);
+    state.activeAttackCards.push(pendingAtk2);
 
     DurakEngine.endRound(state, 'player1');
 
-    expect(player.hand).toHaveLength(2);
+    expect(player.hand).toHaveLength(3);
     expect(player.hand.filter((card) => card.suit === Suit.Hearts && card.rank === Rank.Nine)).toHaveLength(1);
     expect(player.hand.filter((card) => card.suit === Suit.Spades && card.rank === Rank.Eight)).toHaveLength(1);
-    expect(player.lastDrawLog).toHaveLength(2);
+    expect(player.hand.filter((card) => card.suit === Suit.Clubs && card.rank === Rank.Ten)).toHaveLength(1);
+    expect(player.lastDrawLog).toHaveLength(3);
   });
 
   test('handleDefend Logic Simulation - Pairing verification', () => {


### PR DESCRIPTION
Fixed card duplication caused by handleDefend pushing defense cards to both table and activeAttackCards. Also added conservation tests.