### PR TITLE
feat: Discord Auto-Lobby with Colonist-style Host Lobby

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -433,7 +433,7 @@ export const GameBoard: React.FC = () => {
               className="absolute inset-0 z-50 flex flex-col md:flex-row items-stretch justify-center bg-black/80 backdrop-blur-md rounded-2xl overflow-hidden"
             >
               {/* Left Side: Settings Panel */}
-              <div className="w-full md:w-1/3 md:max-w-xs bg-black/60 border-r border-white/10 p-4 md:p-6 flex flex-col overflow-y-auto">
+              <div className="w-full md:w-1/3 md:max-w-xs bg-black/60 border-b md:border-b-0 md:border-r border-white/10 p-4 md:p-6 flex flex-col md:overflow-y-auto shrink-0 md:shrink">
                 <h2 className="text-xl md:text-2xl font-black text-white mb-4 md:mb-6 uppercase tracking-wider text-center border-b border-white/10 pb-4">
                   Game Settings
                 </h2>
@@ -606,7 +606,7 @@ export const GameBoard: React.FC = () => {
                   </div>
                 )}
 
-                <div className="flex-1 overflow-y-auto custom-scrollbar">
+                <div className="flex-1 overflow-y-auto custom-scrollbar min-h-[150px]">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4 pb-20 md:pb-0">
                     {Array.from(gameState.players.entries()).map(([id, p]) => (
                       <div
@@ -669,7 +669,7 @@ export const GameBoard: React.FC = () => {
 
                 {/* Mobile Host Start Game Button */}
                 {room.sessionId === gameState.hostId && (
-                  <div className="md:hidden mt-4 pt-4 border-t border-white/10">
+                  <div className="md:hidden mt-auto pt-4 border-t border-white/10 bg-black/60 p-4 shrink-0">
                     <button
                       onClick={startLobbyGame}
                       disabled={
@@ -693,7 +693,7 @@ export const GameBoard: React.FC = () => {
 
                 {/* Guest Ready Button / Host Ready Toggle */}
                 {room.sessionId !== gameState.hostId && (
-                  <div className="mt-4 md:mt-6 pt-4 md:pt-6 border-t border-white/10 flex flex-col md:flex-row items-center justify-between gap-3 md:gap-0">
+                  <div className="mt-auto pt-4 border-t border-white/10 flex flex-col md:flex-row items-center justify-between gap-3 md:gap-0 bg-black/60 p-4 shrink-0">
                     <p className="text-gray-400 text-xs md:text-sm font-medium">
                       Waiting for host to start...
                     </p>
@@ -711,7 +711,7 @@ export const GameBoard: React.FC = () => {
                 )}
 
                 {room.sessionId === gameState.hostId && !myPlayer?.isReady && (
-                  <div className="absolute top-4 right-4 md:bottom-6 md:right-6 md:top-auto">
+                  <div className="absolute top-4 right-4 md:bottom-6 md:right-6 md:top-auto z-10">
                     <button
                       onClick={handleToggleReady}
                       className="px-4 py-2 md:px-6 md:py-3 text-xs md:text-sm bg-white/10 hover:bg-white/20 text-white rounded-xl font-bold shadow-lg transition-all active:scale-95"
@@ -721,7 +721,7 @@ export const GameBoard: React.FC = () => {
                   </div>
                 )}
                 {room.sessionId === gameState.hostId && myPlayer?.isReady && (
-                  <div className="absolute top-4 right-4 md:bottom-6 md:right-6 md:top-auto">
+                  <div className="absolute top-4 right-4 md:bottom-6 md:right-6 md:top-auto z-10">
                     <button
                       onClick={handleToggleReady}
                       className="px-4 py-2 md:px-6 md:py-3 text-xs md:text-sm bg-green-900/40 text-green-400 rounded-xl font-bold border border-green-500/30 transition-all active:scale-95"


### PR DESCRIPTION
## Summary
Implements the Discord Activity auto-lobby system and redesigns the waiting phase into a Colonist-style Host-Guest lobby.

### Discord Auto-Lobby
- Auto-join rooms tied to Discord voice channel instances via `discordInstanceId` filtering
- Extract and display Discord user avatars and usernames in-game
- OAuth token exchange via `/api/token` endpoint

### Host-Guest Lobby (Colonist-style)
- First player becomes **Host** with full control over game settings
- Host can configure: Game Mode, Team Selection, Max Players, Starting Hand Size
- Guests see read-only settings and must click **Ready** before Host can start
- Host reassignment if the original host leaves
- Deck/Huzur generation deferred to game start (not room creation)

### Production Deployment Fixes
- Added `VITE_DISCORD_CLIENT_ID` to Dockerfile for proper client build
- Set `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` as Fly.io secrets
- Memory-safe `ts-node --transpile-only` for production runtime
- `Content-Security-Policy: frame-ancestors *` for Discord iframe embedding

### Mobile UI Fixes
- Fixed lobby layout so action buttons (Start Game / Ready) are sticky at the bottom on small screens