### PR TITLE
fix: reset replay state and remove 6-card lobby option

### DIFF
--- a/packages/client/src/components/Card.tsx
+++ b/packages/client/src/components/Card.tsx
@@ -55,8 +55,8 @@ export const Card: React.FC<CardProps> = ({
     return (
       <div
         className={`
-          relative w-10 h-[60px] bg-white rounded shadow border border-gray-300
-          flex flex-col justify-between p-0.5 select-none text-[10px]
+          relative w-12 h-[72px] bg-white rounded-md shadow border border-gray-300
+          flex flex-col justify-between p-0.5 select-none text-[11px]
           ${isPlayable ? 'cursor-pointer' : 'opacity-90'}
           ${className}
         `}

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -278,7 +278,7 @@ export const GameBoard: React.FC = () => {
                     }
                     className="w-full bg-green-900/50 text-white border border-green-500/50 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-400 appearance-none font-bold shadow-inner"
                   >
-                    {[5, 6, 7].map((n) => (
+                    {[5, 7].map((n) => (
                       <option key={n} value={n}>
                         {n} Cards
                       </option>

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -565,7 +565,7 @@ export const GameBoard: React.FC = () => {
                     {def ? (
                       <UICard card={def} compact className="ring-1 ring-green-500/30" />
                     ) : (
-                      <div className="w-10 h-[60px] rounded border border-dashed border-white/20 flex items-center justify-center">
+                      <div className="w-12 h-[72px] rounded-md border border-dashed border-white/20 flex items-center justify-center">
                         <span className="text-[6px] text-white/30">?</span>
                       </div>
                     )}

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -149,7 +149,15 @@ export class DurakRoom extends Room<GameState> {
 
     // Start Game Manually
     this.onMessage('startGame', (client) => {
-      if (this.state.phase !== 'waiting' || client.sessionId !== this.state.hostId) return;
+      if (client.sessionId !== this.state.hostId) return;
+
+      if (this.state.phase === 'finished') {
+        this.resetGameStateForReplay();
+        this.startGame();
+        return;
+      }
+
+      if (this.state.phase !== 'waiting') return;
 
       const allReady = Array.from(this.state.players.values()).every((p) => p.isReady);
       if (!allReady) {
@@ -228,6 +236,8 @@ export class DurakRoom extends Room<GameState> {
 
   private startGame() {
     this.state.phase = 'playing';
+    this.state.seatOrder.splice(0, this.state.seatOrder.length);
+    this.state.lastDefenseAt = 0;
 
     // Initialize the deck right before game starts
     const deck = DurakEngine.createDeck();
@@ -314,6 +324,37 @@ export class DurakRoom extends Room<GameState> {
 
     // Start turn timeout enforcement
     this.startTurnTimer();
+  }
+
+  private resetGameStateForReplay() {
+    if (this.turnTimeoutId) {
+      clearInterval(this.turnTimeoutId);
+      this.turnTimeoutId = null;
+    }
+
+    this.state.deck.splice(0, this.state.deck.length);
+    this.state.discardPile.splice(0, this.state.discardPile.length);
+    this.state.table.splice(0, this.state.table.length);
+    this.state.tableStacks.splice(0, this.state.tableStacks.length);
+    this.state.activeAttackCards.splice(0, this.state.activeAttackCards.length);
+    this.state.winners.splice(0, this.state.winners.length);
+    this.state.actionLog.splice(0, this.state.actionLog.length);
+
+    this.state.huzurCard = new Card();
+    this.state.huzurSuit = '';
+    this.state.currentTurn = '';
+    this.state.defenseChainCount = 0;
+    this.state.phase = 'waiting';
+    this.state.turnStartTime = 0;
+    this.state.lastDefenseAt = 0;
+    this.state.loser = '';
+
+    this.state.players.forEach((player) => {
+      player.hand.splice(0, player.hand.length);
+      player.pickedUpCardKeys.splice(0, player.pickedUpCardKeys.length);
+      player.hasPickedUp = false;
+      player.lastDrawLog.splice(0, player.lastDrawLog.length);
+    });
   }
 
   private startTurnTimer() {

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -144,7 +144,10 @@ export class DurakRoom extends Room<GameState> {
         this.state.maxPlayers = parseInt(message.maxPlayers, 10);
         this.maxClients = this.state.maxPlayers;
       }
-      if (message.targetHandSize) this.state.targetHandSize = parseInt(message.targetHandSize, 10);
+      if (message.targetHandSize) {
+        const requestedHandSize = parseInt(message.targetHandSize, 10);
+        this.state.targetHandSize = requestedHandSize === 7 ? 7 : 5;
+      }
     });
 
     // Start Game Manually
@@ -235,6 +238,8 @@ export class DurakRoom extends Room<GameState> {
   }
 
   private startGame() {
+    this.clearRoundStateForNewGame();
+
     this.state.phase = 'playing';
     this.state.seatOrder.splice(0, this.state.seatOrder.length);
     this.state.lastDefenseAt = 0;
@@ -326,7 +331,7 @@ export class DurakRoom extends Room<GameState> {
     this.startTurnTimer();
   }
 
-  private resetGameStateForReplay() {
+  private clearRoundStateForNewGame() {
     if (this.turnTimeoutId) {
       clearInterval(this.turnTimeoutId);
       this.turnTimeoutId = null;
@@ -344,7 +349,6 @@ export class DurakRoom extends Room<GameState> {
     this.state.huzurSuit = '';
     this.state.currentTurn = '';
     this.state.defenseChainCount = 0;
-    this.state.phase = 'waiting';
     this.state.turnStartTime = 0;
     this.state.lastDefenseAt = 0;
     this.state.loser = '';
@@ -355,6 +359,10 @@ export class DurakRoom extends Room<GameState> {
       player.hasPickedUp = false;
       player.lastDrawLog.splice(0, player.lastDrawLog.length);
     });
+  }
+
+  private resetGameStateForReplay() {
+    this.state.phase = 'waiting';
   }
 
   private startTurnTimer() {


### PR DESCRIPTION
This PR includes the replay fix commit and the lobby restriction cleanup:\n\n- resets replay state so the deck/table don’t accumulate across rematches\n- removes the invalid 6-card starting hand option from the lobby\n- updates the server replay flow in \n- updates the lobby UI in \n\nCommit included: 