### PR TITLE
fix: allow 7-card mass attack in 7-card lobbies (#125)

### DIFF
--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -189,7 +189,7 @@ export class DurakEngine {
     } else if (requiredSize === 5) {
       // In 5-card lobbies, 5-card mass only allowed when deck is empty.
       // In 7-card lobbies, 5-card mass is always allowed.
-      if (targetHandSize < 7 && deckSize > 0) return false;
+      if (targetHandSize !== 7 && deckSize > 0) return false;
       return DurakEngine.countPairs(cards) >= 2;
     } else if (requiredSize === 7) {
       // 7-card mass is only allowed in 7-card lobbies, when the deck is empty.

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -165,9 +165,10 @@ export class DurakEngine {
   }
 
   /**
-   * Mass = 3 or 5 cards based on conditions.
+   * Mass = 3, 5, or 7 cards based on conditions.
    * 3-Card Mass: 1 pair + 1 random card. (Denied if anyone has < 3 cards)
    * 5-Card Mass: 2 pairs + 1 random card. (Only if deck empty AND everyone has >= 5 cards)
+   * 7-Card Mass: 3 pairs + 1 random card. (Only if deck empty AND everyone has >= 7 cards in 7-card lobbies)
    */
   static isValidMassAttack(
     cards: Card[],
@@ -176,7 +177,7 @@ export class DurakEngine {
     targetHandSize: number = 5,
   ): boolean {
     const requiredSize = cards.length;
-    if (requiredSize !== 3 && requiredSize !== 5) return false;
+    if (requiredSize !== 3 && requiredSize !== 5 && requiredSize !== 7) return false;
 
     // Check if everyone has enough cards
     for (const p of allPlayers) {
@@ -185,12 +186,18 @@ export class DurakEngine {
 
     if (requiredSize === 3) {
       return DurakEngine.countPairs(cards) >= 1;
-    } else {
+    } else if (requiredSize === 5) {
       // In 5-card lobbies, 5-card mass only allowed when deck is empty.
       // In 7-card lobbies, 5-card mass is always allowed.
       if (targetHandSize < 7 && deckSize > 0) return false;
       return DurakEngine.countPairs(cards) >= 2;
+    } else if (requiredSize === 7) {
+      // 7-card mass is only allowed in 7-card lobbies, when the deck is empty.
+      if (targetHandSize < 7 || deckSize > 0) return false;
+      return DurakEngine.countPairs(cards) >= 3;
     }
+
+    return false;
   }
 
   private static countPairs(cards: Card[]): number {

--- a/packages/shared/src/engine/DurakEngine.ts
+++ b/packages/shared/src/engine/DurakEngine.ts
@@ -193,7 +193,7 @@ export class DurakEngine {
       return DurakEngine.countPairs(cards) >= 2;
     } else if (requiredSize === 7) {
       // 7-card mass is only allowed in 7-card lobbies, when the deck is empty.
-      if (targetHandSize < 7 || deckSize > 0) return false;
+      if (targetHandSize !== 7 || deckSize > 0) return false;
       return DurakEngine.countPairs(cards) >= 3;
     }
 

--- a/packages/shared/tests/DurakEngine.test.ts
+++ b/packages/shared/tests/DurakEngine.test.ts
@@ -237,6 +237,18 @@ describe('DurakEngine - Custom Rules', () => {
       // Target hand size 5, Deck size 0 -> invalid
       expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 0, 5)).toBe(false);
 
+      // Less than 3 pairs -> invalid
+      const atkCardsFewPairs = [
+        new Card(Suit.Hearts, Rank.Jack),
+        new Card(Suit.Spades, Rank.Jack),
+        new Card(Suit.Diamonds, Rank.Nine),
+        new Card(Suit.Clubs, Rank.Nine),
+        new Card(Suit.Hearts, Rank.Queen),
+        new Card(Suit.Spades, Rank.King),
+        new Card(Suit.Diamonds, Rank.Ace),
+      ];
+      expect(DurakEngine.isValidMassAttack(atkCardsFewPairs, [p1, p2], 0, 7)).toBe(false);
+
       // Someone has < 7 cards -> invalid
       p2.hand.pop();
       expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 0, 7)).toBe(false);

--- a/packages/shared/tests/DurakEngine.test.ts
+++ b/packages/shared/tests/DurakEngine.test.ts
@@ -208,11 +208,38 @@ describe('DurakEngine - Custom Rules', () => {
       p1.hand.push(...new Array(7).fill(new Card()));
       const p2 = new Player('p2');
       p2.hand.push(...new Array(7).fill(new Card()));
-      // 7-card lobby allows 5-card mass even with deck
-      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 28, 7)).toBe(true);
-      // But 5-card lobby (default) blocks it when deck > 0
-      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 28)).toBe(false);
-      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 28, 5)).toBe(false);
+
+      // Target hand size 7, Deck size 10
+      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 10, 7)).toBe(true);
+    });
+
+    test('7-Card Mass: Allowed in 7-card lobby only when deck is empty', () => {
+      const atkCards = [
+        new Card(Suit.Hearts, Rank.Jack),
+        new Card(Suit.Spades, Rank.Jack),
+        new Card(Suit.Diamonds, Rank.Nine),
+        new Card(Suit.Clubs, Rank.Nine),
+        new Card(Suit.Hearts, Rank.Queen),
+        new Card(Suit.Spades, Rank.Queen),
+        new Card(Suit.Diamonds, Rank.King),
+      ];
+      const p1 = new Player('p1');
+      p1.hand.push(...new Array(7).fill(new Card()));
+      const p2 = new Player('p2');
+      p2.hand.push(...new Array(7).fill(new Card()));
+
+      // Target hand size 7, Deck size 0 -> valid
+      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 0, 7)).toBe(true);
+
+      // Target hand size 7, Deck size 10 -> invalid
+      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 10, 7)).toBe(false);
+
+      // Target hand size 5, Deck size 0 -> invalid
+      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 0, 5)).toBe(false);
+
+      // Someone has < 7 cards -> invalid
+      p2.hand.pop();
+      expect(DurakEngine.isValidMassAttack(atkCards, [p1, p2], 0, 7)).toBe(false);
     });
 
     test('5-Card Mass: Valid in 5-card lobby when deck is empty', () => {


### PR DESCRIPTION
Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 7-card mass attacks with distinct validation rules.
  * Updated mass attack validation to enforce varying pair requirements and deck/hand constraints based on attack size (3, 5, or 7 cards).

* **Tests**
  * Expanded test coverage for mass attack validation scenarios including new 7-card attack cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->