### PR TITLE
Fix defense snapshot visibility (Issue #124)

### DIFF
--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -110,6 +110,10 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     });
 
+    roomInstance.onMessage('clearDefenseSnapshot', () => {
+      setDefenseSnapshot(null);
+    });
+
     roomInstance.onMessage('error', (message: string) => {
       setGameMessage(`Error: ${message}`);
       setTimeout(() => setGameMessage(null), 4000);

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -420,6 +420,8 @@ export class DurakRoom extends Room<GameState> {
   private handleAttack(client: Client, message: { cards: any[] }) {
     if (this.state.currentTurn !== client.sessionId) return;
 
+    this.broadcast('clearDefenseSnapshot');
+
     const player = this.state.players.get(client.sessionId)!;
     const cardsToPlay = message.cards.map((c) => new Card(c.suit, c.rank, c.isJoker));
 
@@ -600,6 +602,8 @@ export class DurakRoom extends Room<GameState> {
 
   private handlePickUp(client: Client) {
     if (this.state.currentTurn !== client.sessionId) return;
+
+    this.broadcast('clearDefenseSnapshot');
 
     // Track cards BEFORE they are moved to hand by endRound
     const pickedUpCards: string[] = [];

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -385,6 +385,7 @@ export class DurakRoom extends Room<GameState> {
         // Auto-pickup: the defender (currentTurn) must pick up
         const player = this.state.players.get(currentPlayerId);
         if (player && this.state.activeAttackCards.length > 0) {
+          this.broadcast('clearDefenseSnapshot');
           // Force pickup on the defender
           DurakEngine.endRound(this.state, currentPlayerId);
           DurakEngine.replenishAll(this.state);
@@ -420,8 +421,6 @@ export class DurakRoom extends Room<GameState> {
   private handleAttack(client: Client, message: { cards: any[] }) {
     if (this.state.currentTurn !== client.sessionId) return;
 
-    this.broadcast('clearDefenseSnapshot');
-
     const player = this.state.players.get(client.sessionId)!;
     const cardsToPlay = message.cards.map((c) => new Card(c.suit, c.rank, c.isJoker));
 
@@ -449,6 +448,8 @@ export class DurakRoom extends Room<GameState> {
         return;
       }
     }
+
+    this.broadcast('clearDefenseSnapshot');
 
     // Move cards from hand to active attack
     cardsToPlay.forEach((c) => {


### PR DESCRIPTION
Resolves #124 by dispatching clearDefenseSnapshot event from server when the next attack or pickup occurs, clearing the snapshot early on the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defense snapshot is now cleared immediately on server-driven events (including forced pickup by timeout and at the start of attack/pickup actions), preventing stale UI state and improving gameplay consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->