### PR TITLE
feat(client): Developer tools in full-screen lobby

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -187,10 +187,17 @@ export const GameBoard: React.FC = () => {
       <div className="fixed inset-0 z-50 flex flex-col bg-green-950 text-white overflow-hidden safe-p">
         {/* Compact header */}
         <div className="flex items-center justify-between px-4 py-2 border-b border-green-700/50 shrink-0 bg-black/30">
-          <h1 className="text-lg font-extrabold tracking-tight text-green-100">
-            ♦ Durak <span className="text-yellow-400">Online</span> ♦
-          </h1>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <h1 className="text-lg font-extrabold tracking-tight text-green-100 truncate">
+              ♦ Durak <span className="text-yellow-400">Online</span> ♦
+            </h1>
+            {isDevMode && (
+              <span className="shrink-0 text-[9px] font-black uppercase tracking-wide text-orange-300 bg-orange-950/90 px-2 py-0.5 rounded border border-orange-500/45">
+                Dev
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
             <span className="text-[10px] text-gray-400 uppercase font-bold">Room</span>
             <span className="text-xs font-mono text-yellow-400 bg-black/50 px-2 py-1 rounded border border-yellow-500/20 select-all cursor-pointer">
               {room.id}
@@ -290,6 +297,32 @@ export const GameBoard: React.FC = () => {
                   </div>
                 )}
               </div>
+
+              {isDevMode && (
+                <div className="mt-4 pt-4 border-t border-orange-500/35 space-y-2 shrink-0">
+                  <h3 className="text-[11px] font-black text-orange-300 uppercase tracking-wider border-b border-orange-500/25 pb-1.5">
+                    Developer
+                  </h3>
+                  <p className="text-[9px] text-gray-500 leading-snug">
+                    Bots spawn as ready players so you can start a match solo or fill empty seats.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={devSpawnDummies}
+                    disabled={gameState.players.size >= gameState.maxPlayers}
+                    className="w-full bg-orange-900/55 hover:bg-orange-800/70 disabled:opacity-40 disabled:cursor-not-allowed text-orange-50 text-xs font-bold py-2 px-3 rounded-lg border border-orange-500/40 transition"
+                  >
+                    Spawn bots (fill to {gameState.maxPlayers})
+                  </button>
+                  <button
+                    type="button"
+                    onClick={devCopyLog}
+                    className="w-full bg-slate-800/80 hover:bg-slate-700 text-slate-200 text-xs font-bold py-2 px-3 rounded-lg border border-slate-500/35 transition"
+                  >
+                    Copy action log ({gameState.actionLog?.length || 0})
+                  </button>
+                </div>
+              )}
             </div>
           </div>
 
@@ -491,29 +524,32 @@ export const GameBoard: React.FC = () => {
         )}
       </AnimatePresence>
 
-      {/* ── Dev Tools Panel ── */}
+      {/* ── Developer (in-match) ── */}
       {isDevMode && (
-        <div className="absolute top-12 right-2 bg-red-950/90 text-white p-2 rounded-xl border-2 border-red-500 shadow-2xl z-50 flex flex-col space-y-1 backdrop-blur-md w-40 text-[10px]">
-          <div className="font-bold uppercase tracking-widest border-b border-red-500/50 pb-1 text-red-300">
-            Dev Tools
+        <div className="absolute top-12 right-2 bg-orange-950/92 text-white p-2 rounded-xl border-2 border-orange-500/70 shadow-2xl z-50 flex flex-col space-y-1.5 backdrop-blur-md w-44 text-[10px]">
+          <div className="font-black uppercase tracking-wider border-b border-orange-500/45 pb-1 text-orange-200">
+            Developer
           </div>
           <button
+            type="button"
             onClick={devSpawnDummies}
-            className="bg-red-800 hover:bg-red-700 px-2 py-1 rounded transition border border-red-600"
+            className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left"
           >
-            Spawn Dummies
+            Spawn bots
           </button>
           <button
+            type="button"
             onClick={devForcePass}
-            className="bg-red-800 hover:bg-red-700 px-2 py-1 rounded transition border border-red-600"
+            className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left"
           >
-            Force Pass
+            Force pass turn
           </button>
           <button
+            type="button"
             onClick={devCopyLog}
-            className="bg-blue-800 hover:bg-blue-700 px-2 py-1 rounded transition border border-blue-600"
+            className="bg-slate-800 hover:bg-slate-700 px-2 py-1.5 rounded-lg transition border border-slate-500/45 font-bold text-left"
           >
-            Copy Log ({gameState.actionLog?.length || 0})
+            Copy log ({gameState.actionLog?.length || 0})
           </button>
         </div>
       )}

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -151,14 +151,23 @@ export const GameBoard: React.FC = () => {
     typeof window !== 'undefined' &&
     new URLSearchParams(window.location.search).get('dev') === 'true';
 
-  const devSpawnDummies = () => room.send('dev_action', { action: 'spawn_dummies' });
-  const devForcePass = () => room.send('dev_action', { action: 'force_pass' });
+  const isHost = !!gameState.hostId && room.sessionId === gameState.hostId;
+
+  const devSpawnDummies = () => {
+    if (!isHost) return;
+    room.send('dev_action', { action: 'spawn_dummies' });
+  };
+
+  const devForcePass = () => {
+    if (!isHost) return;
+    room.send('dev_action', { action: 'force_pass' });
+  };
   const devCopyLog = () => {
     const logStr = Array.from(gameState.actionLog || []).join('\n');
     navigator.clipboard.writeText(logStr).then(() => alert('Game Log Copied to Clipboard!'));
   };
   const handleDevCardClick = (oppId: string, card: SharedCard) => {
-    if (!isDevMode) return;
+    if (!isDevMode || !isHost) return;
     setDevSelectedCards((prev) => {
       const selected = prev[oppId] || [];
       const alreadySelected = selected.find((c) => c.suit === card.suit && c.rank === card.rank);
@@ -170,6 +179,7 @@ export const GameBoard: React.FC = () => {
   };
 
   const handleDevAction = (oppId: string, type: 'attack' | 'defend' | 'pickUp' | 'swapHuzur') => {
+    if (!isHost) return;
     room.send('dev_action', {
       action: 'play_as',
       asPlayerId: oppId,
@@ -309,7 +319,7 @@ export const GameBoard: React.FC = () => {
                   <button
                     type="button"
                     onClick={devSpawnDummies}
-                    disabled={gameState.players.size >= gameState.maxPlayers}
+                    disabled={!isHost || gameState.players.size >= gameState.maxPlayers}
                     className="w-full bg-orange-900/55 hover:bg-orange-800/70 disabled:opacity-40 disabled:cursor-not-allowed text-orange-50 text-xs font-bold py-2 px-3 rounded-lg border border-orange-500/40 transition"
                   >
                     Spawn bots (fill to {gameState.maxPlayers})
@@ -533,14 +543,16 @@ export const GameBoard: React.FC = () => {
           <button
             type="button"
             onClick={devSpawnDummies}
-            className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left"
+            disabled={!isHost}
+            className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Spawn bots
           </button>
           <button
             type="button"
             onClick={devForcePass}
-            className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left"
+            disabled={!isHost}
+            className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Force pass turn
           </button>
@@ -712,7 +724,7 @@ export const GameBoard: React.FC = () => {
                       <div
                         key={ci}
                         onClick={() => handleDevCardClick(id, c)}
-                        className={`cursor-pointer ${
+                        className={`${!isHost ? 'pointer-events-none' : 'cursor-pointer'} ${
                           (devSelectedCards[id] || []).find(
                             (sc) => sc.suit === c.suit && sc.rank === c.rank,
                           )
@@ -726,26 +738,30 @@ export const GameBoard: React.FC = () => {
                 </div>
                 <div className="flex gap-0.5 mt-0.5 justify-center">
                   <button
+                    disabled={!isHost}
                     onClick={() => handleDevAction(id, 'attack')}
-                    className="bg-red-600 text-[8px] px-1 py-0.5 rounded"
+                    className="bg-red-600 text-[8px] px-1 py-0.5 rounded disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     Atk
                   </button>
                   <button
+                    disabled={!isHost}
                     onClick={() => handleDevAction(id, 'defend')}
-                    className="bg-green-600 text-[8px] px-1 py-0.5 rounded"
+                    className="bg-green-600 text-[8px] px-1 py-0.5 rounded disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     Def
                   </button>
                   <button
+                    disabled={!isHost}
                     onClick={() => handleDevAction(id, 'pickUp')}
-                    className="bg-yellow-600 text-[8px] px-1 py-0.5 rounded"
+                    className="bg-yellow-600 text-[8px] px-1 py-0.5 rounded disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     Pick
                   </button>
                   <button
+                    disabled={!isHost}
                     onClick={() => handleDevAction(id, 'swapHuzur')}
-                    className="bg-purple-600 text-[8px] px-1 py-0.5 rounded"
+                    className="bg-purple-600 text-[8px] px-1 py-0.5 rounded disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     Swap
                   </button>

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -50,6 +50,9 @@ export class DurakRoom extends Room<GameState> {
     // Developer Mode Action Handler
     this.onMessage('dev_action', (client, message) => {
       // NOTE: In a real app, verify process.env.NODE_ENV !== "production"
+      // Host-only: only the lobby leader can mutate game state via dev actions.
+      if (client.sessionId !== this.state.hostId) return;
+
       if (message.action === 'spawn_dummies') {
         const currentPlayers = this.state.players.size;
         // Default to filling the room to maxPlayers (6)


### PR DESCRIPTION
## Summary
Surfaces developer-mode actions in the new full-screen waiting lobby so local testing does not require an in-progress match.

## Changes
- **Lobby (waiting phase):** When `?dev=true`, a **Developer** block appears under Game Settings with **Spawn bots** (fill to `maxPlayers`) and **Copy action log**. Spawn is disabled when the room is full.
- **Lobby header:** Small **Dev** pill when developer mode is active.
- **Playing phase:** Developer floating panel restyled (orange/slate) and labels clarified (**Force pass turn**, **Copy log**, etc.). Existing `play_as` opponent-hand controls are unchanged.

## How to test
1. Run client with `?dev=true` in the URL.
2. Join or create a room; in the lobby sidebar, use **Spawn bots** to fill dummy players, then start as host when ready.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Developer section to lobby settings with bot spawning and action-log copying capabilities.

* **Bug Fixes**
  * Developer controls (spawn bots, force pass, copy log, dev card interactions) are restricted to the room host; non-host attempts are ignored and UI controls disabled.

* **Style**
  * Compacted waiting-phase lobby header and title layout.
  * Restyled in-match developer panel and updated button labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->