### PR TITLE
feat(#123): implement suhuh first-turn card draw

### DIFF
--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -327,7 +327,7 @@ export class DurakRoom extends Room<GameState> {
     if (a.isJoker && b.isJoker) return a.rank > b.rank;
     if (a.suit === this.state.huzurSuit && b.suit !== this.state.huzurSuit) return true;
     if (a.suit !== this.state.huzurSuit && b.suit === this.state.huzurSuit) return false;
-    return a.rank > b.rank;
+    return a.suit === b.suit ? a.rank > b.rank : false;
   }
 
   /**
@@ -371,7 +371,7 @@ export class DurakRoom extends Room<GameState> {
         const drawn = this.state.deck.pop()!;
         const card = new Card(drawn.suit, drawn.rank, drawn.isJoker);
         this.state.players.get(repId)!.hand.push(card);
-        this.state.actionLog.push(`suhuh ${repId} (team ${team}): +${this.formatCard(card)}`);
+        this.state.actionLog.push(`suhuh ${repId}: +${this.formatCard(card)}`);
         if (!winningCard || this.cardBeats(card, winningCard)) {
           winningCard = card;
           winningTeam = team;

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -311,24 +311,94 @@ export class DurakRoom extends Room<GameState> {
       this.state.actionLog.push(`turn 0: ${id}: ${drawnCards.join(', ')}`);
     });
 
-    // Set first attacker: player with the lowest Huzur (Trump) card in hand
-    let firstId = Array.from(this.state.players.keys())[0];
-    let lowestTrumpRank = Infinity;
-
-    this.state.players.forEach((player, id) => {
-      player.hand.forEach((card) => {
-        if (card.suit === this.state.huzurSuit && card.rank < lowestTrumpRank) {
-          lowestTrumpRank = card.rank;
-          firstId = id;
-        }
-      });
-    });
-
-    this.state.currentTurn = firstId;
+    // Suhuh: each player (or one rep per team) draws 1 card to determine first attacker.
+    // Highest card wins; falls back to lowest-trump-in-hand if the deck is empty.
+    this.state.currentTurn = this.resolveSuhuh();
     this.state.turnStartTime = Date.now();
 
     // Start turn timeout enforcement
     this.startTurnTimer();
+  }
+
+  /** Returns true if card `a` outranks card `b` for the suhuh draw. */
+  private cardBeats(a: Card, b: Card): boolean {
+    if (a.isJoker && !b.isJoker) return true;
+    if (!a.isJoker && b.isJoker) return false;
+    if (a.isJoker && b.isJoker) return a.rank > b.rank;
+    if (a.suit === this.state.huzurSuit && b.suit !== this.state.huzurSuit) return true;
+    if (a.suit !== this.state.huzurSuit && b.suit === this.state.huzurSuit) return false;
+    return a.rank > b.rank;
+  }
+
+  /**
+   * Suhuh first-turn resolution (issue #123).
+   * Each player draws 1 card; highest card wins. In teams mode only one player
+   * per team draws, and the winning team's first player in seat order starts.
+   * Falls back to lowest-trump-in-hand when the deck is empty after the deal.
+   */
+  private resolveSuhuh(): string {
+    const seatOrder = Array.from(this.state.seatOrder);
+    const fallbackId = seatOrder[0]!;
+
+    if (this.state.deck.length === 0) {
+      // Deck exhausted during deal (e.g. 6p 7-card) — fall back to lowest trump in hand
+      let firstId = fallbackId;
+      let lowestTrumpRank = Infinity;
+      this.state.players.forEach((player, id) => {
+        player.hand.forEach((card) => {
+          if (card.suit === this.state.huzurSuit && card.rank < lowestTrumpRank) {
+            lowestTrumpRank = card.rank;
+            firstId = id;
+          }
+        });
+      });
+      return firstId;
+    }
+
+    if (this.state.mode === 'teams') {
+      // One representative per team draws; winning team's first player in seat order starts
+      const teamReps = new Map<number, string>(); // team -> first player in seat order
+      for (const id of seatOrder) {
+        const team = this.state.players.get(id)!.team;
+        if (!teamReps.has(team)) teamReps.set(team, id);
+      }
+
+      let winningTeam = -1;
+      let winningCard: Card | null = null;
+
+      teamReps.forEach((repId, team) => {
+        if (this.state.deck.length === 0) return;
+        const drawn = this.state.deck.pop()!;
+        const card = new Card(drawn.suit, drawn.rank, drawn.isJoker);
+        this.state.players.get(repId)!.hand.push(card);
+        this.state.actionLog.push(`suhuh ${repId} (team ${team}): +${this.formatCard(card)}`);
+        if (!winningCard || this.cardBeats(card, winningCard)) {
+          winningCard = card;
+          winningTeam = team;
+        }
+      });
+
+      // First player of the winning team in seat order becomes attacker
+      return seatOrder.find((id) => this.state.players.get(id)!.team === winningTeam) ?? fallbackId;
+    } else {
+      // FFA: every player draws one card
+      let firstId = fallbackId;
+      let highCard: Card | null = null;
+
+      for (const id of seatOrder) {
+        if (this.state.deck.length === 0) break;
+        const drawn = this.state.deck.pop()!;
+        const card = new Card(drawn.suit, drawn.rank, drawn.isJoker);
+        this.state.players.get(id)!.hand.push(card);
+        this.state.actionLog.push(`suhuh ${id}: +${this.formatCard(card)}`);
+        if (!highCard || this.cardBeats(card, highCard)) {
+          highCard = card;
+          firstId = id;
+        }
+      }
+
+      return firstId;
+    }
   }
 
   private clearRoundStateForNewGame() {

--- a/packages/server/tests/suhuh.test.ts
+++ b/packages/server/tests/suhuh.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DurakRoom } from '../src/rooms/DurakRoom';
+import { GameState } from '@durak/shared/src/state/GameState';
+import { Player } from '@durak/shared/src/state/Player';
+import { Card } from '@durak/shared/src/state/Card';
+
+describe('Suhuh first-turn draw (#123)', () => {
+  let room: DurakRoom;
+
+  beforeEach(() => {
+    room = new DurakRoom();
+    room.state = new GameState();
+    room.broadcast = vi.fn();
+    (room as any).startTurnTimer = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function setupPlayers(ids: string[], teamMap?: Record<string, number>) {
+    room.state.seatOrder.splice(0, room.state.seatOrder.length);
+    ids.forEach((id) => {
+      const p = new Player(id);
+      if (teamMap) p.team = teamMap[id] ?? 0;
+      room.state.players.set(id, p);
+      room.state.seatOrder.push(id);
+    });
+    room.state.huzurSuit = 'spades';
+  }
+
+  function pushDeckTop(...cards: Card[]) {
+    // Cards pushed last are popped first (top of deck)
+    cards.forEach((c) => room.state.deck.push(c));
+  }
+
+  describe('FFA mode', () => {
+    it('assigns first turn to the player who drew the highest card', () => {
+      setupPlayers(['p1', 'p2', 'p3']);
+      // p3 draws first (last pushed = last popped), p2 second, p1 third
+      // deck pops: p1 gets 7h, p2 gets Ah (high), p3 gets 9h
+      pushDeckTop(new Card('hearts', 7), new Card('hearts', 14), new Card('hearts', 9));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p2'); // Ace of hearts is highest
+    });
+
+    it('picks trump over non-trump of the same rank', () => {
+      setupPlayers(['p1', 'p2']);
+      // pop order: p1 gets last element, p2 gets second-to-last
+      // p1 draws 9s (trump), p2 draws 9h (non-trump)
+      pushDeckTop(new Card('hearts', 9), new Card('spades', 9));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p1');
+    });
+
+    it('picks joker over all other cards', () => {
+      setupPlayers(['p1', 'p2', 'p3']);
+      pushDeckTop(new Card('hearts', 14), new Card('none', 1, true), new Card('spades', 14));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p2'); // p2 draws joker
+    });
+
+    it('drawn cards are added to each player hand', () => {
+      setupPlayers(['p1', 'p2']);
+      pushDeckTop(new Card('clubs', 8), new Card('clubs', 10));
+
+      (room as any).resolveSuhuh();
+
+      expect(room.state.players.get('p1')!.hand.length).toBe(1);
+      expect(room.state.players.get('p2')!.hand.length).toBe(1);
+    });
+
+    it('logs suhuh draws to the action log', () => {
+      setupPlayers(['p1', 'p2']);
+      pushDeckTop(new Card('hearts', 7), new Card('hearts', 9));
+
+      (room as any).resolveSuhuh();
+
+      const log = Array.from(room.state.actionLog);
+      expect(log.some((entry: string) => entry.startsWith('suhuh p1'))).toBe(true);
+      expect(log.some((entry: string) => entry.startsWith('suhuh p2'))).toBe(true);
+    });
+  });
+
+  describe('teams mode', () => {
+    it("only one rep per team draws; winning team's first seat-order player starts", () => {
+      room.state.mode = 'teams';
+      setupPlayers(['p1', 'p2', 'p3', 'p4'], { p1: 0, p2: 1, p3: 0, p4: 1 });
+      // team 0 rep = p1, team 1 rep = p2
+      // pop order: team 0 rep (p1) gets last element, team 1 rep (p2) gets next
+      // p1 draws 7c, p2 draws Ac — team 1 wins, p2 is team 1's first in seat order
+      pushDeckTop(new Card('clubs', 14), new Card('clubs', 7));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p2');
+    });
+
+    it('team 0 wins when their rep draws higher', () => {
+      room.state.mode = 'teams';
+      setupPlayers(['p1', 'p2', 'p3', 'p4'], { p1: 0, p2: 1, p3: 0, p4: 1 });
+      // pop order: team 0 rep (p1) gets last element, team 1 rep (p2) gets next
+      // p1 draws As (trump), p2 draws Kh — team 0 wins
+      pushDeckTop(new Card('hearts', 13), new Card('spades', 14));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p1');
+    });
+  });
+
+  describe('fallback when deck is empty', () => {
+    it('falls back to lowest-trump-in-hand when deck is empty after deal', () => {
+      setupPlayers(['p1', 'p2']);
+      // No cards in deck
+      const p1 = room.state.players.get('p1')!;
+      const p2 = room.state.players.get('p2')!;
+      p1.hand.push(new Card('spades', 7)); // trump 7
+      p2.hand.push(new Card('spades', 9)); // trump 9 — p1 has lower trump so p1 starts
+      p2.hand.push(new Card('hearts', 14));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p1'); // lowest trump wins the first attack
+    });
+
+    it('falls back to first player when no trump in hand either', () => {
+      setupPlayers(['p1', 'p2']);
+      // No deck, no trump cards
+      room.state.players.get('p1')!.hand.push(new Card('hearts', 7));
+      room.state.players.get('p2')!.hand.push(new Card('clubs', 9));
+
+      const firstId = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p1'); // first in seat order
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- After dealing, each player draws 1 card from the remaining deck to determine who attacks first — highest card wins (jokers > trump > off-suit; higher rank breaks same-suit ties)
- Drawn cards go into each player's hand; draws are logged as `suhuh <id>: +<card>`
- In **teams mode** one representative per team draws; the winning team's first player in seat order becomes the first attacker
- **Falls back** to the existing lowest-trump-in-hand heuristic when the deck is exhausted during the deal (e.g. 6-player 7-card game with a 42-card deck)

## Test plan
- [x] `suhuh.test.ts` — 9 unit tests: highest card wins, trump beats off-suit same rank, joker beats all, cards land in hand, action log entries, teams mode (both teams winning), empty-deck fallback with trump and without

Resolves #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game startup now determines the first attacker via a “suhuh” draw (players draw to find the highest card), supporting both classic/FFA and teams modes. Draws are recorded in the game action log and the per-turn timer is started when the first turn begins. Includes fallback selection when the deck is empty.

* **Tests**
  * Added comprehensive tests covering draw selection, team/FFA behavior, action-log recording, and deck-empty fallback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/169)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->