### PR TITLE
feat(#123): suhuh animation, dev panel fix, and winner log

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -188,6 +188,26 @@ export const GameBoard: React.FC = () => {
   if (gameState.phase === 'waiting') {
     return (
       <div className="fixed inset-0 z-50 flex flex-col bg-green-950 text-white overflow-hidden safe-p">
+        {/* ── Dev Tools (waiting phase) ── */}
+        {isDevMode && (
+          <div className="absolute top-12 right-2 bg-red-950/90 text-white p-2 rounded-xl border-2 border-red-500 shadow-2xl z-[60] flex flex-col space-y-1 backdrop-blur-md w-40 text-[10px]">
+            <div className="font-bold uppercase tracking-widest border-b border-red-500/50 pb-1 text-red-300">
+              Dev Tools
+            </div>
+            <button
+              onClick={devSpawnDummies}
+              className="bg-red-800 hover:bg-red-700 px-2 py-1 rounded transition border border-red-600"
+            >
+              Spawn Dummies
+            </button>
+            <button
+              onClick={devCopyLog}
+              className="bg-blue-800 hover:bg-blue-700 px-2 py-1 rounded transition border border-blue-600"
+            >
+              Copy Log ({gameState.actionLog?.length || 0})
+            </button>
+          </div>
+        )}
         {/* Compact header */}
         <div className="flex items-center justify-between px-4 py-2 border-b border-green-700/50 shrink-0 bg-black/30">
           <h1 className="text-lg font-extrabold tracking-tight text-green-100">

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -5,6 +5,7 @@ import { Card as SharedCard, Player } from '@durak/shared';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Haptics, ImpactStyle } from '@capacitor/haptics';
 import { useAudio } from '../utils/audio';
+import { SuhuhReveal } from './SuhuhReveal';
 
 const DealSoundTrigger = ({ delayMs, playSound }: { delayMs: number; playSound: () => void }) => {
   React.useEffect(() => {
@@ -23,6 +24,8 @@ export const GameBoard: React.FC = () => {
     gameMessage,
     clearGameMessage,
     defenseSnapshot,
+    suhuhResult,
+    clearSuhuhResult,
     serverTimeOffset,
     updateLobbySettings,
     startLobbyGame,
@@ -441,6 +444,15 @@ export const GameBoard: React.FC = () => {
 
   return (
     <div className="flex flex-col h-[100dvh] w-full bg-green-950 overflow-hidden safe-p text-white relative">
+      {suhuhResult && (
+        <SuhuhReveal
+          draws={suhuhResult.draws}
+          winnerId={suhuhResult.winnerId}
+          players={gameState.players as unknown as Map<string, Player>}
+          seatOrder={Array.from(gameState.seatOrder)}
+          onDone={clearSuhuhResult}
+        />
+      )}
       {/* ── Info Bar ── */}
       <div className="flex items-center justify-between px-3 py-1.5 bg-black/50 border-b border-green-800/50 shrink-0 z-20">
         <div className="flex items-center gap-3 text-xs">

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -449,7 +449,7 @@ export const GameBoard: React.FC = () => {
           draws={suhuhResult.draws}
           winnerId={suhuhResult.winnerId}
           players={gameState.players as unknown as Map<string, Player>}
-          seatOrder={Array.from(gameState.seatOrder)}
+          seatOrder={Array.from(gameState.seatOrder).filter((id): id is string => id != null)}
           onDone={clearSuhuhResult}
         />
       )}

--- a/packages/client/src/components/SuhuhReveal.tsx
+++ b/packages/client/src/components/SuhuhReveal.tsx
@@ -1,0 +1,213 @@
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Card as UICard } from './Card';
+import { Card as SharedCard } from '@durak/shared';
+import type { Player } from '@durak/shared';
+import type { SuhuhDraw } from '../contexts/GameContext';
+
+interface SuhuhRevealProps {
+  draws: SuhuhDraw[];
+  winnerId: string;
+  players: Map<string, Player>;
+  seatOrder: string[];
+  onDone: () => void;
+}
+
+type Phase = 'drawing' | 'drawn' | 'revealing' | 'highlighting' | 'exiting';
+
+const CardBack: React.FC = () => (
+  <div className="w-full h-full rounded-lg border-2 border-blue-400 bg-blue-800 flex items-center justify-center shadow-lg select-none">
+    <div className="w-[calc(100%-10px)] h-[calc(100%-10px)] rounded border border-blue-300/40 bg-blue-900 flex items-center justify-center">
+      <span className="text-blue-300 text-3xl">♦</span>
+    </div>
+  </div>
+);
+
+interface FlipCardProps {
+  draw: SuhuhDraw;
+  revealed: boolean;
+  highlighted: boolean;
+  entryDelay: number;
+}
+
+const FlipCard: React.FC<FlipCardProps> = ({ draw, revealed, highlighted, entryDelay }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), entryDelay);
+    return () => clearTimeout(t);
+  }, [entryDelay]);
+
+  const card = new SharedCard(draw.suit, draw.rank, draw.isJoker);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: -70 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ type: 'spring', stiffness: 220, damping: 22 }}
+          style={{ perspective: '700px', width: 80, height: 112 }}
+        >
+          <motion.div
+            animate={{ rotateY: revealed ? 180 : 0 }}
+            transition={{ duration: 0.55, ease: 'easeInOut' }}
+            style={{
+              transformStyle: 'preserve-3d',
+              position: 'relative',
+              width: '100%',
+              height: '100%',
+            }}
+            className={highlighted ? 'drop-shadow-[0_0_20px_rgba(250,204,21,0.95)]' : ''}
+          >
+            {/* Back face */}
+            <div style={{ backfaceVisibility: 'hidden', position: 'absolute', inset: 0 }}>
+              <CardBack />
+            </div>
+            {/* Front face */}
+            <div
+              style={{
+                backfaceVisibility: 'hidden',
+                transform: 'rotateY(180deg)',
+                position: 'absolute',
+                inset: 0,
+              }}
+            >
+              <UICard card={card} className="!w-full !h-full" />
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export const SuhuhReveal: React.FC<SuhuhRevealProps> = ({
+  draws,
+  winnerId,
+  players,
+  seatOrder,
+  onDone,
+}) => {
+  const [phase, setPhase] = useState<Phase>('drawing');
+
+  // Sort draws into seat order; players who didn't draw (teams mode) are omitted
+  const orderedDraws = seatOrder
+    .map((id) => draws.find((d) => d.playerId === id))
+    .filter((d): d is SuhuhDraw => d !== undefined);
+
+  useEffect(() => {
+    const lastCardAt = orderedDraws.length * 350 + 300;
+
+    const t1 = setTimeout(() => setPhase('drawn'), lastCardAt + 300);
+    const t2 = setTimeout(() => setPhase('revealing'), lastCardAt + 1100);
+    const t3 = setTimeout(() => setPhase('highlighting'), lastCardAt + 1800);
+    const t4 = setTimeout(() => setPhase('exiting'), lastCardAt + 3900);
+    const t5 = setTimeout(onDone, lastCardAt + 4400);
+
+    return () => [t1, t2, t3, t4, t5].forEach(clearTimeout);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const revealed = phase === 'revealing' || phase === 'highlighting';
+  const winnerPlayer = players.get(winnerId);
+
+  return (
+    <AnimatePresence>
+      {phase !== 'exiting' && (
+        <motion.div
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/80 backdrop-blur-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.35 }}
+        >
+          {/* Title */}
+          <motion.h2
+            className="text-xl font-bold tracking-widest uppercase mb-8"
+            initial={{ opacity: 0, y: -16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.15 }}
+          >
+            {phase === 'highlighting' ? (
+              <span className="text-yellow-300">
+                {winnerPlayer?.username || winnerId} goes first!
+              </span>
+            ) : (
+              <span className="text-white/70">Drawing for first attacker…</span>
+            )}
+          </motion.h2>
+
+          {/* Player slots */}
+          <div className="flex flex-wrap gap-8 justify-center max-w-3xl px-4">
+            {orderedDraws.map((draw, i) => {
+              const player = players.get(draw.playerId);
+              const isWinner = draw.playerId === winnerId;
+              const highlighted = phase === 'highlighting' && isWinner;
+
+              return (
+                <motion.div
+                  key={draw.playerId}
+                  className="flex flex-col items-center gap-3"
+                  animate={highlighted ? { scale: 1.12 } : { scale: 1 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  {/* Avatar + name */}
+                  <div className="flex flex-col items-center gap-1">
+                    {player?.avatarUrl ? (
+                      <img
+                        src={player.avatarUrl}
+                        alt={player.username}
+                        className={`w-10 h-10 rounded-full border-2 transition-all duration-300 ${
+                          highlighted
+                            ? 'border-yellow-400 shadow-[0_0_12px_rgba(250,204,21,0.7)]'
+                            : 'border-white/30'
+                        }`}
+                      />
+                    ) : (
+                      <div
+                        className={`w-10 h-10 rounded-full bg-green-700 flex items-center justify-center text-white font-bold text-sm border-2 transition-all duration-300 ${
+                          highlighted ? 'border-yellow-400' : 'border-white/20'
+                        }`}
+                      >
+                        {(player?.username || draw.playerId).slice(0, 2).toUpperCase()}
+                      </div>
+                    )}
+                    <span
+                      className={`text-sm font-medium transition-colors duration-300 ${
+                        highlighted ? 'text-yellow-300 font-bold' : 'text-white/70'
+                      }`}
+                    >
+                      {player?.username || draw.playerId.slice(0, 8)}
+                    </span>
+                  </div>
+
+                  {/* Card flip */}
+                  <FlipCard
+                    draw={draw}
+                    revealed={revealed}
+                    highlighted={highlighted}
+                    entryDelay={300 + i * 350}
+                  />
+                </motion.div>
+              );
+            })}
+          </div>
+
+          {/* "Highest card wins" subtitle during highlight */}
+          <AnimatePresence>
+            {phase === 'highlighting' && (
+              <motion.p
+                className="mt-8 text-green-400 text-sm tracking-wide"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+              >
+                ♦ Highest card wins ♦
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -10,6 +10,9 @@ type DefenseSnapshot = {
   defending: Array<{ suit: string; rank: number; isJoker: boolean }>;
 } | null;
 
+export type SuhuhDraw = { playerId: string; suit: string; rank: number; isJoker: boolean };
+export type SuhuhResult = { draws: SuhuhDraw[]; winnerId: string } | null;
+
 interface GameContextState {
   client: Client | null;
   room: Room<GameState> | null;
@@ -19,6 +22,8 @@ interface GameContextState {
   gameMessage: string | null;
   clearGameMessage: () => void;
   defenseSnapshot: DefenseSnapshot;
+  suhuhResult: SuhuhResult;
+  clearSuhuhResult: () => void;
   createGame: (options: Record<string, unknown>) => Promise<void>;
   joinGame: (roomId: string) => Promise<void>;
   findPublicGames: () => Promise<RoomAvailable[]>;
@@ -38,6 +43,8 @@ const GameContext = createContext<GameContextState>({
   gameMessage: null,
   clearGameMessage: () => {},
   defenseSnapshot: null,
+  suhuhResult: null,
+  clearSuhuhResult: () => {},
   createGame: async () => {},
   joinGame: async () => {},
   findPublicGames: async () => [],
@@ -78,12 +85,14 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [gameMessage, setGameMessage] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [defenseSnapshot, setDefenseSnapshot] = useState<DefenseSnapshot>(null);
+  const [suhuhResult, setSuhuhResult] = useState<SuhuhResult>(null);
   const [serverTimeOffset, setServerTimeOffset] = useState<number>(0);
   // Colyseus mutates state in place, so we need a manual tick to trigger React updates
   const [, setTick] = useState(0);
   const gameState = room?.state || null;
 
   const clearGameMessage = () => setGameMessage(null);
+  const clearSuhuhResult = () => setSuhuhResult(null);
 
   const handleRoomEvents = (roomInstance: Room<GameState>) => {
     roomInstance.onStateChange(() => setTick((t) => t + 1));
@@ -112,6 +121,10 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     roomInstance.onMessage('clearDefenseSnapshot', () => {
       setDefenseSnapshot(null);
+    });
+
+    roomInstance.onMessage('suhuhResult', (data: { draws: SuhuhDraw[]; winnerId: string }) => {
+      setSuhuhResult(data);
     });
 
     roomInstance.onMessage('error', (message: string) => {
@@ -233,6 +246,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         gameMessage,
         clearGameMessage,
         defenseSnapshot,
+        suhuhResult,
+        clearSuhuhResult,
         createGame,
         joinGame,
         findPublicGames,

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -230,6 +230,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   useEffect(() => {
+    if (!room) setSuhuhResult(null);
     return () => {
       if (room) room.leave();
     };

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -162,6 +162,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       console.log('Left room:', code);
       setIsConnected(false);
       setRoom(null);
+      setSuhuhResult(null);
     });
     setRoom(roomInstance);
     setIsConnected(true);
@@ -230,7 +231,6 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   useEffect(() => {
-    if (!room) setSuhuhResult(null);
     return () => {
       if (room) room.leave();
     };

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -317,6 +317,7 @@ export class DurakRoom extends Room<GameState> {
     this.state.currentTurn = firstId;
     if (draws.length > 0) {
       this.broadcast('suhuhResult', { draws, winnerId: firstId });
+      this.state.actionLog.push(`suhuh first: ${firstId}`);
     }
     this.state.turnStartTime = Date.now();
 

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -317,7 +317,6 @@ export class DurakRoom extends Room<GameState> {
     this.state.currentTurn = firstId;
     if (draws.length > 0) {
       this.broadcast('suhuhResult', { draws, winnerId: firstId });
-      this.state.actionLog.push(`suhuh first: ${firstId}`);
     }
     this.state.turnStartTime = Date.now();
 
@@ -360,6 +359,7 @@ export class DurakRoom extends Room<GameState> {
           }
         });
       });
+      this.state.actionLog.push(`suhuh first: ${firstId}`);
       return { firstId, draws: [] };
     }
 
@@ -391,6 +391,7 @@ export class DurakRoom extends Room<GameState> {
 
       const firstId =
         seatOrder.find((id) => this.state.players.get(id)!.team === winningTeam) ?? fallbackId;
+      this.state.actionLog.push(`suhuh first: ${firstId}`);
       return { firstId, draws };
     } else {
       // FFA: every player draws one card
@@ -410,6 +411,7 @@ export class DurakRoom extends Room<GameState> {
         }
       }
 
+      this.state.actionLog.push(`suhuh first: ${firstId}`);
       return { firstId, draws };
     }
   }

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -313,7 +313,11 @@ export class DurakRoom extends Room<GameState> {
 
     // Suhuh: each player (or one rep per team) draws 1 card to determine first attacker.
     // Highest card wins; falls back to lowest-trump-in-hand if the deck is empty.
-    this.state.currentTurn = this.resolveSuhuh();
+    const { firstId, draws } = this.resolveSuhuh();
+    this.state.currentTurn = firstId;
+    if (draws.length > 0) {
+      this.broadcast('suhuhResult', { draws, winnerId: firstId });
+    }
     this.state.turnStartTime = Date.now();
 
     // Start turn timeout enforcement
@@ -336,8 +340,11 @@ export class DurakRoom extends Room<GameState> {
    * per team draws, and the winning team's first player in seat order starts.
    * Falls back to lowest-trump-in-hand when the deck is empty after the deal.
    */
-  private resolveSuhuh(): string {
-    const seatOrder = Array.from(this.state.seatOrder);
+  private resolveSuhuh(): {
+    firstId: string;
+    draws: Array<{ playerId: string; suit: string; rank: number; isJoker: boolean }>;
+  } {
+    const seatOrder = Array.from(this.state.seatOrder).filter((id): id is string => id != null);
     const fallbackId = seatOrder[0]!;
 
     if (this.state.deck.length === 0) {
@@ -352,8 +359,10 @@ export class DurakRoom extends Room<GameState> {
           }
         });
       });
-      return firstId;
+      return { firstId, draws: [] };
     }
+
+    const draws: Array<{ playerId: string; suit: string; rank: number; isJoker: boolean }> = [];
 
     if (this.state.mode === 'teams') {
       // One representative per team draws; winning team's first player in seat order starts
@@ -372,14 +381,16 @@ export class DurakRoom extends Room<GameState> {
         const card = new Card(drawn.suit, drawn.rank, drawn.isJoker);
         this.state.players.get(repId)!.hand.push(card);
         this.state.actionLog.push(`suhuh ${repId}: +${this.formatCard(card)}`);
+        draws.push({ playerId: repId, suit: card.suit, rank: card.rank, isJoker: card.isJoker });
         if (!winningCard || this.cardBeats(card, winningCard)) {
           winningCard = card;
           winningTeam = team;
         }
       });
 
-      // First player of the winning team in seat order becomes attacker
-      return seatOrder.find((id) => this.state.players.get(id)!.team === winningTeam) ?? fallbackId;
+      const firstId =
+        seatOrder.find((id) => this.state.players.get(id)!.team === winningTeam) ?? fallbackId;
+      return { firstId, draws };
     } else {
       // FFA: every player draws one card
       let firstId = fallbackId;
@@ -391,13 +402,14 @@ export class DurakRoom extends Room<GameState> {
         const card = new Card(drawn.suit, drawn.rank, drawn.isJoker);
         this.state.players.get(id)!.hand.push(card);
         this.state.actionLog.push(`suhuh ${id}: +${this.formatCard(card)}`);
+        draws.push({ playerId: id, suit: card.suit, rank: card.rank, isJoker: card.isJoker });
         if (!highCard || this.cardBeats(card, highCard)) {
           highCard = card;
           firstId = id;
         }
       }
 
-      return firstId;
+      return { firstId, draws };
     }
   }
 

--- a/packages/server/tests/suhuh.test.ts
+++ b/packages/server/tests/suhuh.test.ts
@@ -41,7 +41,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       // deck pops: p1 gets 7h, p2 gets Ah (high), p3 gets 9h
       pushDeckTop(new Card('hearts', 7), new Card('hearts', 14), new Card('hearts', 9));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p2'); // Ace of hearts is highest
     });
 
@@ -51,7 +51,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       // p1 draws 9s (trump), p2 draws 9h (non-trump)
       pushDeckTop(new Card('hearts', 9), new Card('spades', 9));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p1');
     });
 
@@ -59,7 +59,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       setupPlayers(['p1', 'p2', 'p3']);
       pushDeckTop(new Card('hearts', 14), new Card('none', 1, true), new Card('spades', 14));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p2'); // p2 draws joker
     });
 
@@ -79,9 +79,9 @@ describe('Suhuh first-turn draw (#123)', () => {
 
       (room as any).resolveSuhuh();
 
-      const log = Array.from(room.state.actionLog);
-      expect(log.some((entry: string) => entry.startsWith('suhuh p1'))).toBe(true);
-      expect(log.some((entry: string) => entry.startsWith('suhuh p2'))).toBe(true);
+      const log = Array.from(room.state.actionLog).filter((e): e is string => e != null);
+      expect(log.some((entry) => entry.startsWith('suhuh p1'))).toBe(true);
+      expect(log.some((entry) => entry.startsWith('suhuh p2'))).toBe(true);
     });
   });
 
@@ -94,7 +94,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       // p1 draws 7c, p2 draws Ac — team 1 wins, p2 is team 1's first in seat order
       pushDeckTop(new Card('clubs', 14), new Card('clubs', 7));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p2');
     });
 
@@ -105,7 +105,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       // p1 draws As (trump), p2 draws Kh — team 0 wins
       pushDeckTop(new Card('hearts', 13), new Card('spades', 14));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p1');
     });
   });
@@ -120,7 +120,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       p2.hand.push(new Card('spades', 9)); // trump 9 — p1 has lower trump so p1 starts
       p2.hand.push(new Card('hearts', 14));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p1'); // lowest trump wins the first attack
     });
 
@@ -130,7 +130,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       room.state.players.get('p1')!.hand.push(new Card('hearts', 7));
       room.state.players.get('p2')!.hand.push(new Card('clubs', 9));
 
-      const firstId = (room as any).resolveSuhuh();
+      const { firstId } = (room as any).resolveSuhuh();
       expect(firstId).toBe('p1'); // first in seat order
     });
   });

--- a/packages/server/tests/suhuh.test.ts
+++ b/packages/server/tests/suhuh.test.ts
@@ -82,6 +82,7 @@ describe('Suhuh first-turn draw (#123)', () => {
       const log = Array.from(room.state.actionLog).filter((e): e is string => e != null);
       expect(log.some((entry) => entry.startsWith('suhuh p1'))).toBe(true);
       expect(log.some((entry) => entry.startsWith('suhuh p2'))).toBe(true);
+      expect(log.some((entry) => entry.startsWith('suhuh first:'))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `SuhuhReveal` animation: cards fly in face-down one by one, all flip simultaneously, winner highlighted with gold glow
- Wires up `suhuhResult` message in `GameContext` so the animation triggers on game start
- Logs `suhuh first: <playerId>` to `actionLog` so the winner of the draw is persisted
- Fixes dev panel (Spawn Dummies / Copy Log) not showing during the waiting-phase lobby
- Fixes `ArraySchema<string>` undefined leak when passing `seatOrder` to `SuhuhReveal`

## Test plan

- [ ] Start a game with 2+ players — cards should fly in face-down then flip revealing all draws, winner glows gold
- [ ] Copy Log in dev mode shows `suhuh p1: +Xr`, `suhuh p2: +Xr`, `suhuh first: pN` entries
- [ ] `?dev=true` shows Spawn Dummies button in the waiting lobby
- [ ] No TypeScript build errors (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated Suhuh reveal overlay that shows each player's drawn card and highlights the winner.
  * Dev-only lobby tools to spawn dummy players and copy the action log.

* **Bug Fixes / Gameplay**
  * Suhuh resolution now reliably determines the first attacker (teams and FFA) and handles depleted decks when resolving draws.

* **Tests**
  * Updated Suhuh tests to match the new draw/result behavior and logging checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/170)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->