### PR TITLE
feat(#138): implement Colyseus reconnection

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -6,7 +6,8 @@ import { isEmbedded, setupDiscordSdk, discordSdk, type DiscordAuthInfo } from '.
 import './App.css';
 
 function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
-  const { room, isConnected, error, leaveGame, autoJoinDiscordRoom, gameState } = useGame();
+  const { room, isConnected, isReconnecting, error, leaveGame, autoJoinDiscordRoom, gameState } =
+    useGame();
 
   // Issue #69: Auto-join the Discord Instance Lobby
   useEffect(() => {
@@ -68,7 +69,14 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
           </div>
         )}
 
-        {!isConnected ? (
+        {isReconnecting ? (
+          <div className="flex flex-col items-center justify-center h-64 space-y-4">
+            <div className="w-12 h-12 border-4 border-yellow-500 border-t-transparent rounded-full animate-spin"></div>
+            <div className="text-yellow-400 font-bold animate-pulse uppercase tracking-widest text-sm">
+              Reconnecting…
+            </div>
+          </div>
+        ) : !isConnected ? (
           isEmbedded ? (
             <div className="flex flex-col items-center justify-center h-64 space-y-4">
               <div className="w-12 h-12 border-4 border-green-500 border-t-transparent rounded-full animate-spin"></div>

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -286,19 +286,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // On mount: if there's a saved reconnection token (e.g. after a page refresh), restore session
   useEffect(() => {
-    const token = sessionStorage.getItem(RECONNECT_TOKEN_KEY);
-    if (token) {
-      setIsReconnecting(true);
-      client
-        .reconnect<GameState>(token)
-        .then((newRoom) => {
-          handleRoomEvents(newRoom);
-          setIsReconnecting(false);
-        })
-        .catch(() => {
-          sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
-          setIsReconnecting(false);
-        });
+    if (sessionStorage.getItem(RECONNECT_TOKEN_KEY)) {
+      attemptReconnect();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState, useMemo } from 'react';
+import React, { createContext, useContext, useEffect, useState, useMemo, useRef } from 'react';
 import { Client, Room } from 'colyseus.js';
 import type { RoomAvailable } from 'colyseus.js';
 import { GameState } from '@durak/shared';
@@ -13,11 +13,16 @@ type DefenseSnapshot = {
 export type SuhuhDraw = { playerId: string; suit: string; rank: number; isJoker: boolean };
 export type SuhuhResult = { draws: SuhuhDraw[]; winnerId: string } | null;
 
+const RECONNECT_TOKEN_KEY = 'durak_reconnection_token';
+const MAX_RECONNECT_ATTEMPTS = 3;
+const RECONNECT_DELAYS = [500, 2000, 4000]; // ms per attempt
+
 interface GameContextState {
   client: Client | null;
   room: Room<GameState> | null;
   error: string | null;
   isConnected: boolean;
+  isReconnecting: boolean;
   gameState: GameState | null;
   gameMessage: string | null;
   clearGameMessage: () => void;
@@ -39,6 +44,7 @@ const GameContext = createContext<GameContextState>({
   room: null,
   error: null,
   isConnected: false,
+  isReconnecting: false,
   gameState: null,
   gameMessage: null,
   clearGameMessage: () => {},
@@ -84,6 +90,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [error, setError] = useState<string | null>(null);
   const [gameMessage, setGameMessage] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const [defenseSnapshot, setDefenseSnapshot] = useState<DefenseSnapshot>(null);
   const [suhuhResult, setSuhuhResult] = useState<SuhuhResult>(null);
   const [serverTimeOffset, setServerTimeOffset] = useState<number>(0);
@@ -91,10 +98,44 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [, setTick] = useState(0);
   const gameState = room?.state || null;
 
+  // Stable ref so onLeave can access the latest client without a stale closure
+  const clientRef = useRef(client);
+  useEffect(() => {
+    clientRef.current = client;
+  }, [client]);
+
   const clearGameMessage = () => setGameMessage(null);
   const clearSuhuhResult = () => setSuhuhResult(null);
 
+  const attemptReconnect = async () => {
+    const token = sessionStorage.getItem(RECONNECT_TOKEN_KEY);
+    if (!token) return false;
+
+    setIsReconnecting(true);
+    for (let i = 0; i < MAX_RECONNECT_ATTEMPTS; i++) {
+      await new Promise((res) => setTimeout(res, RECONNECT_DELAYS[i]));
+      try {
+        const newRoom = await clientRef.current.reconnect<GameState>(token);
+        handleRoomEvents(newRoom);
+        setIsReconnecting(false);
+        return true;
+      } catch {
+        // continue to next attempt
+      }
+    }
+
+    // All attempts exhausted
+    sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
+    setIsReconnecting(false);
+    return false;
+  };
+
   const handleRoomEvents = (roomInstance: Room<GameState>) => {
+    // Persist token so the client can reconnect after a network drop or page refresh
+    if (roomInstance.reconnectionToken) {
+      sessionStorage.setItem(RECONNECT_TOKEN_KEY, roomInstance.reconnectionToken);
+    }
+
     roomInstance.onStateChange(() => setTick((t) => t + 1));
 
     // Calculate server time offset
@@ -145,6 +186,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
             ? '😭 Game Over. You are the Durak (Fool)!'
             : `🎉 Game Over! ${data.loser} is the Durak.`,
         );
+      // Game is over — no reconnection needed after this point
+      sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
     });
     roomInstance.onMessage('turnExpired', (data: { playerId: string }) => {
       setGameMessage(
@@ -158,11 +201,21 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       console.error('Room error:', code, message);
       setError(message || 'Unknown room error');
     });
-    roomInstance.onLeave((code) => {
+    roomInstance.onLeave(async (code) => {
       console.log('Left room:', code);
       setIsConnected(false);
       setRoom(null);
       setSuhuhResult(null);
+
+      // WebSocket close codes: 1000 = normal, 4000+ = room-level consented closes.
+      // Anything else is an unexpected drop — try to reconnect.
+      const isCleanExit = code === 1000 || code >= 4000;
+      if (!isCleanExit) {
+        const reconnected = await attemptReconnect();
+        if (reconnected) return;
+      }
+
+      sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
     });
     setRoom(roomInstance);
     setIsConnected(true);
@@ -214,6 +267,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const leaveGame = () => {
     if (room) {
+      sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
       room.leave();
     }
   };
@@ -230,6 +284,25 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
+  // On mount: if there's a saved reconnection token (e.g. after a page refresh), restore session
+  useEffect(() => {
+    const token = sessionStorage.getItem(RECONNECT_TOKEN_KEY);
+    if (token) {
+      setIsReconnecting(true);
+      client
+        .reconnect<GameState>(token)
+        .then((newRoom) => {
+          handleRoomEvents(newRoom);
+          setIsReconnecting(false);
+        })
+        .catch(() => {
+          sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
+          setIsReconnecting(false);
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     return () => {
       if (room) room.leave();
@@ -243,6 +316,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         room,
         error,
         isConnected,
+        isReconnecting,
         gameState,
         gameMessage,
         clearGameMessage,

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -223,6 +223,10 @@ export class DurakRoom extends Room<GameState> {
     const isInGame = this.state.phase === 'playing';
 
     if (isInGame && !consented) {
+      const player = this.state.players.get(client.sessionId);
+      const displayName = player?.username || client.sessionId.slice(0, 6);
+      this.broadcast('info', `${displayName} disconnected. Waiting up to 30s for reconnection...`);
+
       // Schedule auto-pickup after 5s if it's their turn, so the game doesn't freeze
       let pickupTimer: NodeJS.Timeout | null = null;
       if (this.state.currentTurn === client.sessionId) {
@@ -240,7 +244,8 @@ export class DurakRoom extends Room<GameState> {
       try {
         await this.allowReconnection(client, 30);
         if (pickupTimer) clearTimeout(pickupTimer);
-        return; // Client reconnected - nothing more to do
+        this.broadcast('info', `${displayName} reconnected.`);
+        return;
       } catch {
         if (pickupTimer) clearTimeout(pickupTimer);
         // Reconnection window expired - fall through to permanent removal


### PR DESCRIPTION
## Summary

- **Server**: broadcasts `info` messages to the room when a player disconnects and when they successfully reconnect, so other players know what's happening during the 30s window
- **Client**: persists `room.reconnectionToken` to `sessionStorage` on join; auto-reconnects on unexpected disconnect (up to 3 attempts: 500ms / 2s / 4s back-off); reconnects immediately on page refresh if a token is present
- **UI**: exposes `isReconnecting` from `GameContext` and shows a yellow "Reconnecting…" spinner in `App.tsx` instead of the lobby during reconnect attempts
- Token is cleared on: explicit `leaveGame()`, `gameOver` message, or failed reconnect after all attempts

## How reconnection works

```
Player drops → server: allowReconnection(client, 30s) → auto-pickup fires at 5s if their turn
                                                         ↓
Client: onLeave(code < 4000) → attemptReconnect() with token → client.reconnect(token)
                                                         ↓ success
                              handleRoomEvents(newRoom) → Colyseus sends full state patch
```

Page refresh path:
```
mount → sessionStorage.getItem(RECONNECT_TOKEN_KEY) → client.reconnect(token) → handleRoomEvents
```

## Test plan

- [ ] All 20 server tests pass
- [ ] Simulate network drop mid-game → "Reconnecting…" spinner appears → reconnects and resumes seat
- [ ] Page refresh mid-game → reconnects automatically on reload
- [ ] Explicit "Leave Game" → no reconnect attempt, token cleared
- [ ] Other players see "[name] disconnected" / "[name] reconnected" info messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a centered "Reconnecting…" status while automatically attempting to restore a game connection after unexpected disconnects
  * Automatically restores active game sessions after page refresh or temporary network interruptions
  * Notifies players when someone disconnects mid-game and when that player successfully reconnects

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/173)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->