### PR TITLE
fix(#139): rate limiting and string input sanitization

### DIFF
--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -421,7 +421,7 @@ export class DurakRoom extends Room<GameState> {
     if (a.isJoker && b.isJoker) return a.rank > b.rank;
     if (a.suit === this.state.huzurSuit && b.suit !== this.state.huzurSuit) return true;
     if (a.suit !== this.state.huzurSuit && b.suit === this.state.huzurSuit) return false;
-    return a.suit === b.suit ? a.rank > b.rank : false;
+    return a.rank > b.rank;
   }
 
   /**

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -16,7 +16,7 @@ export class DurakRoom extends Room<GameState> {
   private turnTimeoutId: NodeJS.Timeout | null = null;
   private testModeDeck?: any;
   private botIds = new Map<string, BotDifficulty>(); // sessionId → difficulty
-  private rateLimitMap = new Map<string, { count: number; windowStart: number }>();
+  private rateLimitMap = new Map<string, number[]>(); // sessionId → timestamps
 
   onCreate(options: any) {
     this.setState(new GameState());
@@ -29,11 +29,11 @@ export class DurakRoom extends Room<GameState> {
     this.setPrivate(this.state.isPrivate);
 
     if (options.mode) {
-      this.state.mode = String(options.mode);
+      this.state.mode = String(options.mode).slice(0, MAX_SHORT_STRING_LEN);
     } // "classic" | "teams" etc. (defaults to "classic" in GameState)
 
     if (options.teamSelection) {
-      this.state.teamSelection = String(options.teamSelection);
+      this.state.teamSelection = String(options.teamSelection).slice(0, MAX_SHORT_STRING_LEN);
     }
 
     if (options.handSize) {
@@ -71,6 +71,7 @@ export class DurakRoom extends Room<GameState> {
 
     // Developer Mode Action Handler
     this.onMessage('dev_action', (client, message) => {
+      if (this.isRateLimited(client.sessionId)) return;
       // NOTE: In a real app, verify process.env.NODE_ENV !== "production"
       // Host-only: only the lobby leader can mutate game state via dev actions.
       if (client.sessionId !== this.state.hostId) return;
@@ -628,13 +629,16 @@ export class DurakRoom extends Room<GameState> {
 
   private isRateLimited(sessionId: string): boolean {
     const now = Date.now();
-    const entry = this.rateLimitMap.get(sessionId);
-    if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
-      this.rateLimitMap.set(sessionId, { count: 1, windowStart: now });
-      return false;
+    const cutoff = now - RATE_LIMIT_WINDOW_MS;
+    const timestamps = this.rateLimitMap.get(sessionId) ?? [];
+    // Prune entries outside the sliding window
+    const recent = timestamps.filter((t) => t > cutoff);
+    if (recent.length >= RATE_LIMIT_MAX) {
+      this.rateLimitMap.set(sessionId, recent);
+      return true;
     }
-    if (entry.count >= RATE_LIMIT_MAX) return true;
-    entry.count++;
+    recent.push(now);
+    this.rateLimitMap.set(sessionId, recent);
     return false;
   }
 

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -5,11 +5,18 @@ import { GameLog } from '../models/GameLog';
 import mongoose from 'mongoose';
 import { openAIBot, BotDifficulty } from '../ai/OpenAIBot';
 
+const RATE_LIMIT_MAX = 10; // messages per window
+const RATE_LIMIT_WINDOW_MS = 1000;
+const MAX_USERNAME_LEN = 32;
+const MAX_AVATAR_URL_LEN = 256;
+const MAX_SHORT_STRING_LEN = 32; // mode, teamSelection, etc.
+
 export class DurakRoom extends Room<GameState> {
   maxClients = 6;
   private turnTimeoutId: NodeJS.Timeout | null = null;
   private testModeDeck?: any;
   private botIds = new Map<string, BotDifficulty>(); // sessionId → difficulty
+  private rateLimitMap = new Map<string, { count: number; windowStart: number }>();
 
   onCreate(options: any) {
     this.setState(new GameState());
@@ -41,11 +48,24 @@ export class DurakRoom extends Room<GameState> {
     this.testModeDeck = options.testModeDeck;
 
     // Register Handlers
-    this.onMessage('attack', (client, message) => this.handleAttack(client, message));
-    this.onMessage('defend', (client, message) => this.handleDefend(client, message));
-    this.onMessage('pickUp', (client) => this.handlePickUp(client));
-    this.onMessage('swapHuzur', (client) => this.handleSwapHuzur(client));
+    this.onMessage('attack', (client, message) => {
+      if (this.isRateLimited(client.sessionId)) return;
+      this.handleAttack(client, message);
+    });
+    this.onMessage('defend', (client, message) => {
+      if (this.isRateLimited(client.sessionId)) return;
+      this.handleDefend(client, message);
+    });
+    this.onMessage('pickUp', (client) => {
+      if (this.isRateLimited(client.sessionId)) return;
+      this.handlePickUp(client);
+    });
+    this.onMessage('swapHuzur', (client) => {
+      if (this.isRateLimited(client.sessionId)) return;
+      this.handleSwapHuzur(client);
+    });
     this.onMessage('ping', (client, message: { clientTime: number }) => {
+      if (this.isRateLimited(client.sessionId)) return;
       client.send('pong', { clientTime: message.clientTime, serverTime: Date.now() });
     });
 
@@ -103,6 +123,7 @@ export class DurakRoom extends Room<GameState> {
 
     // Team selection handler in lobby
     this.onMessage('switchTeam', (client, message) => {
+      if (this.isRateLimited(client.sessionId)) return;
       if (
         this.state.phase === 'waiting' &&
         this.state.mode === 'teams' &&
@@ -143,9 +164,11 @@ export class DurakRoom extends Room<GameState> {
 
     // Update Lobby Settings
     this.onMessage('updateSettings', (client, message) => {
+      if (this.isRateLimited(client.sessionId)) return;
       if (this.state.phase !== 'waiting' || client.sessionId !== this.state.hostId) return;
-      if (message.mode) this.state.mode = message.mode;
-      if (message.teamSelection) this.state.teamSelection = message.teamSelection;
+      if (message.mode) this.state.mode = String(message.mode).slice(0, MAX_SHORT_STRING_LEN);
+      if (message.teamSelection)
+        this.state.teamSelection = String(message.teamSelection).slice(0, MAX_SHORT_STRING_LEN);
       if (message.maxPlayers) {
         this.state.maxPlayers = parseInt(message.maxPlayers, 10);
         this.maxClients = this.state.maxPlayers;
@@ -158,6 +181,7 @@ export class DurakRoom extends Room<GameState> {
 
     // Start Game Manually
     this.onMessage('startGame', (client) => {
+      if (this.isRateLimited(client.sessionId)) return;
       if (client.sessionId !== this.state.hostId) return;
 
       if (this.state.phase === 'finished') {
@@ -196,6 +220,7 @@ export class DurakRoom extends Room<GameState> {
 
     // Allow players to ready up manually
     this.onMessage('toggleReady', (client, message) => {
+      if (this.isRateLimited(client.sessionId)) return;
       if (this.state.phase !== 'waiting') return;
       const player = this.state.players.get(client.sessionId);
       if (player) {
@@ -208,8 +233,10 @@ export class DurakRoom extends Room<GameState> {
     console.log(client.sessionId, 'joined!');
 
     const player = new Player(client.sessionId);
-    if (options.username) player.username = options.username;
-    if (options.avatarUrl) player.avatarUrl = options.avatarUrl;
+    if (options.username)
+      player.username = String(options.username).trim().slice(0, MAX_USERNAME_LEN);
+    if (options.avatarUrl)
+      player.avatarUrl = String(options.avatarUrl).trim().slice(0, MAX_AVATAR_URL_LEN);
 
     // First player is host
     if (this.state.players.size === 0) {
@@ -222,6 +249,7 @@ export class DurakRoom extends Room<GameState> {
 
   async onLeave(client: Client, consented: boolean) {
     console.log(client.sessionId, 'left!', consented ? '(consented)' : '(unexpected)');
+    this.rateLimitMap.delete(client.sessionId);
 
     const isInGame = this.state.phase === 'playing';
 
@@ -596,6 +624,18 @@ export class DurakRoom extends Room<GameState> {
       else if (move.action === 'defend') this.handleDefend(fakeClient, { cards: move.cards });
       else if (move.action === 'pickup') this.handlePickUp(fakeClient);
     }, delay);
+  }
+
+  private isRateLimited(sessionId: string): boolean {
+    const now = Date.now();
+    const entry = this.rateLimitMap.get(sessionId);
+    if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+      this.rateLimitMap.set(sessionId, { count: 1, windowStart: now });
+      return false;
+    }
+    if (entry.count >= RATE_LIMIT_MAX) return true;
+    entry.count++;
+    return false;
   }
 
   private parseCards(raw: any): Card[] | null {


### PR DESCRIPTION
## Summary

### fix(#139): Rate limiting and string input sanitization
- **Rate limiting**: every message handler is gated by a per-client sliding-window limiter — max 10 messages/second. Excess messages are silently dropped. Entry deleted on `onLeave` to prevent memory leaks.
- **String sanitization**: `username` trimmed + capped at 32 chars, `avatarUrl` at 256 chars (in `onJoin`). `mode` and `teamSelection` capped at 32 chars in `updateSettings`.
- Card payload validation was already covered by #149 — skipped here.

### fix(#177): Suhuh off-suit non-trump rank comparison
- `cardBeats()` previously returned `false` when both cards were non-trump different suits, so the first-drawn card always won regardless of rank. Changed `a.suit === b.suit ? a.rank > b.rank : false` → `a.rank > b.rank`. Trump-vs-non-trump cases are already handled above that line.

## What's protected (rate limiting)

| Handler | Rate limited | String sanitized |
|---------|-------------|-----------------|
| `attack` / `defend` / `pickUp` / `swapHuzur` | ✅ | — |
| `ping` | ✅ | — |
| `switchTeam` / `toggleReady` / `startGame` | ✅ | — |
| `updateSettings` | ✅ | mode, teamSelection |
| `onJoin` | — | username, avatarUrl |

## Testing

All 20 existing server tests pass.

Closes #139
Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-session rate limiting on multiple player and lobby actions to reduce spam and improve stability; rate state is cleared when a client leaves.
  * Normalized and truncated player display names, avatar URLs, and short setting fields to fixed maximum lengths.
  * Hardened handling of malformed or excessive requests.
  * Adjusted card comparison so ties are resolved by rank when suits don't determine a winner.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/176)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->