### PR TITLE
feat(#135): mobile-responsive layout improvements

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -5,6 +5,7 @@ import { Card as SharedCard, Player } from '@durak/shared';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Haptics, ImpactStyle } from '@capacitor/haptics';
 import { useAudio } from '../utils/audio';
+import { useIsDesktop } from '../utils/useIsDesktop';
 import { SuhuhReveal } from './SuhuhReveal';
 
 const DealSoundTrigger = ({ delayMs, playSound }: { delayMs: number; playSound: () => void }) => {
@@ -34,6 +35,7 @@ export const GameBoard: React.FC = () => {
   const [devSelectedCards, setDevSelectedCards] = useState<Record<string, SharedCard[]>>({});
   const [timeRemaining, setTimeRemaining] = useState<number>(0);
   const { playDealSound } = useAudio();
+  const isDesktop = useIsDesktop();
 
   // Update timer smoothly using requestAnimationFrame
   useEffect(() => {
@@ -827,7 +829,7 @@ export const GameBoard: React.FC = () => {
 
       {/* ── Action Buttons ── */}
       {gameState.phase === 'playing' && (
-        <div className="flex flex-wrap justify-center gap-1.5 md:gap-2 px-2 py-1 shrink-0 z-20">
+        <div className="flex flex-wrap justify-center gap-1.5 md:gap-2 px-2 py-1 shrink-0 z-20 touch-manipulation">
           {isMyTurn && attackCards.length === 0 && (
             <button
               onClick={handleAttack}
@@ -896,7 +898,6 @@ export const GameBoard: React.FC = () => {
                   (c) => c.suit === card.suit && c.rank === card.rank,
                 );
                 const animationDelayMs = i * 150;
-                const isDesktop = typeof window !== 'undefined' ? window.innerWidth >= 768 : true;
                 const overlapAmount =
                   isDesktop && myHand.length > 7 ? Math.min(80, (myHand.length - 7) * 4) : 0;
 
@@ -922,10 +923,12 @@ export const GameBoard: React.FC = () => {
                       marginLeft: i > 0 && isDesktop ? `-${overlapAmount}px` : undefined,
                       zIndex: isSelected ? 100 : i,
                     }}
-                    className={`cursor-pointer rounded-lg flex-shrink-0 relative ${
+                    className={`cursor-pointer rounded-lg flex-shrink-0 relative touch-manipulation ${
                       isSelected
                         ? 'shadow-[0_8px_16px_rgba(250,204,21,0.5)] ring-2 ring-yellow-400'
-                        : 'hover:shadow-[0_0_8px_rgba(255,255,255,0.3)] hover:-translate-y-3 hover:z-[90]'
+                        : isDesktop
+                          ? 'hover:shadow-[0_0_8px_rgba(255,255,255,0.3)] hover:-translate-y-3 hover:z-[90]'
+                          : ''
                     }`}
                   >
                     <DealSoundTrigger delayMs={animationDelayMs} playSound={playDealSound} />

--- a/packages/client/src/utils/useIsDesktop.ts
+++ b/packages/client/src/utils/useIsDesktop.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const DESKTOP_QUERY = '(min-width: 768px)';
+
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(DESKTOP_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(DESKTOP_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isDesktop;
+}


### PR DESCRIPTION
## Summary

- **`useIsDesktop` hook** (`src/utils/useIsDesktop.ts`) — uses `window.matchMedia('(min-width: 768px)')` with a `change` event listener so the layout correctly responds to orientation changes. Previously `GameBoard` read `window.innerWidth` once at render time and never updated.
- **Hover-lift removed on touch** — `hover:-translate-y-3 hover:z-[90]` on card wrappers is now only applied on desktop. On iOS, hover states can stick after a tap-and-hold; the spring animation (`y: isSelected ? -12 : 0`) already provides clear selection feedback on all devices.
- **`touch-manipulation`** added to card wrappers and the action button row — eliminates the 300 ms synthetic-click delay on mobile browsers that don't yet default to fast-tap behaviour.

## What's already fine (not changed)

- Cards already use `w-16 h-24 sm:w-20 sm:h-28 md:w-24 md:h-36` responsive sizing
- Hand row already uses `overflow-x-auto md:overflow-x-visible` for scrolling on small screens
- Action buttons already use `flex-wrap` for portrait layout
- Seat positions use percentage-based `top`/`left` so they scale with viewport

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI & Interaction Improvements**
  * Enhanced touch interaction experience on game board action buttons for improved usability on mobile and tablet devices
  * Updated hover and tap styling for more responsive visual feedback
  * Improved responsive design handling across different screen sizes

* **Performance Optimizations**
  * Optimized game board rendering to reduce unnecessary updates and improve responsiveness

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->