### PR TITLE
feat: player profiles, Discord OAuth, email auth, discard animation, bot fixes

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -35,8 +35,10 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
     }
   }, [discordAuth, isConnected, room, autoJoinDiscordRoom]);
 
-  // Resolve the active Discord identity: embedded SDK auth takes priority over browser OAuth
-  const activeDiscordId = discordAuth?.user.id ?? browserAuth?.id;
+  // Resolve the active identity: embedded SDK > browser Discord OAuth > email account
+  const activeDiscordId =
+    discordAuth?.user.id ?? (browserAuth?.method === 'discord' ? browserAuth.id : undefined);
+  const activeUserId = browserAuth?.method === 'email' ? browserAuth.id : undefined;
   const activeUsername =
     discordAuth?.user.global_name ||
     discordAuth?.user.username ||
@@ -102,6 +104,7 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
           ) : (
             <Lobby
               discordId={activeDiscordId}
+              userId={activeUserId}
               username={activeUsername}
               avatarUrl={activeAvatarUrl}
             />

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,11 +3,22 @@ import { useEffect, useState } from 'react';
 import { GameBoard } from './components/GameBoard';
 import { Lobby } from './components/Lobby';
 import { isEmbedded, setupDiscordSdk, discordSdk, type DiscordAuthInfo } from './discordAuth';
+import { useAuth } from './contexts/AuthContext';
 import './App.css';
 
 function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
   const { room, isConnected, isReconnecting, error, leaveGame, autoJoinDiscordRoom, gameState } =
     useGame();
+  const { user: browserAuth, handleOAuthCallback } = useAuth();
+
+  // Handle Discord OAuth callback (?code=...) for browser login
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    if (code && !isEmbedded) {
+      void handleOAuthCallback(code);
+    }
+  }, [handleOAuthCallback]);
 
   // Issue #69: Auto-join the Discord Instance Lobby
   useEffect(() => {
@@ -24,6 +35,17 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
     }
   }, [discordAuth, isConnected, room, autoJoinDiscordRoom]);
 
+  // Resolve the active Discord identity: embedded SDK auth takes priority over browser OAuth
+  const activeDiscordId = discordAuth?.user.id ?? browserAuth?.id;
+  const activeUsername =
+    discordAuth?.user.global_name ||
+    discordAuth?.user.username ||
+    browserAuth?.globalName ||
+    browserAuth?.username;
+  const activeAvatarUrl = discordAuth?.user.avatar
+    ? `https://cdn.discordapp.com/avatars/${discordAuth.user.id}/${discordAuth.user.avatar}.png?size=128`
+    : browserAuth?.avatarUrl;
+
   // When in waiting phase, GameBoard renders a full-screen lobby — hide all App chrome
   const isWaitingPhase = isConnected && gameState?.phase === 'waiting';
 
@@ -34,16 +56,9 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
   return (
     <div className="min-h-screen bg-green-950 text-white flex flex-col p-4 md:p-8 relative safe-p">
       <header className="flex justify-between items-center mb-6 border-b border-green-800 pb-4">
-        <div className="flex items-center space-x-4">
-          <h1 className="text-3xl font-extrabold tracking-tight text-white drop-shadow-md">
-            ♦ Durak <span className="text-yellow-400">Online</span> ♦
-          </h1>
-          {discordAuth && (
-            <div className="bg-indigo-900/50 text-indigo-200 px-3 py-1 rounded text-xs ml-4 border border-indigo-500/50">
-              Discord Connected as <span className="font-bold">{discordAuth.user.username}</span>
-            </div>
-          )}
-        </div>
+        <h1 className="text-3xl font-extrabold tracking-tight text-white drop-shadow-md">
+          ♦ Durak <span className="text-yellow-400">Online</span> ♦
+        </h1>
         {isConnected && room && (
           <div className="flex space-x-4 items-center">
             <div className="bg-black/50 px-4 py-2 rounded-full text-xs font-mono shadow-inner border border-white/10 flex items-center space-x-2">
@@ -86,13 +101,9 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
             </div>
           ) : (
             <Lobby
-              discordId={discordAuth?.user.id}
-              username={discordAuth?.user.global_name || discordAuth?.user.username}
-              avatarUrl={
-                discordAuth?.user.avatar
-                  ? `https://cdn.discordapp.com/avatars/${discordAuth.user.id}/${discordAuth.user.avatar}.png?size=128`
-                  : undefined
-              }
+              discordId={activeDiscordId}
+              username={activeUsername}
+              avatarUrl={activeAvatarUrl}
             />
           )
         ) : (

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -20,7 +20,7 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
         ? `https://cdn.discordapp.com/avatars/${userId}/${avatarHash}.png?size=128`
         : `https://cdn.discordapp.com/embed/avatars/${parseInt(userId || '0') % 5}.png`;
 
-      autoJoinDiscordRoom(discordSdk.instanceId, username, avatarUrl);
+      autoJoinDiscordRoom(discordSdk.instanceId, username, avatarUrl, userId);
     }
   }, [discordAuth, isConnected, room, autoJoinDiscordRoom]);
 
@@ -85,7 +85,15 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
               </div>
             </div>
           ) : (
-            <Lobby />
+            <Lobby
+              discordId={discordAuth?.user.id}
+              username={discordAuth?.user.global_name || discordAuth?.user.username}
+              avatarUrl={
+                discordAuth?.user.avatar
+                  ? `https://cdn.discordapp.com/avatars/${discordAuth.user.id}/${discordAuth.user.avatar}.png?size=128`
+                  : undefined
+              }
+            />
           )
         ) : (
           <GameBoard />

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -7,6 +7,7 @@ import { Haptics, ImpactStyle } from '@capacitor/haptics';
 import { useAudio } from '../utils/audio';
 import { useIsDesktop } from '../utils/useIsDesktop';
 import { SuhuhReveal } from './SuhuhReveal';
+import { PlayerProfilePanel } from './PlayerProfilePanel';
 
 const DealSoundTrigger = ({ delayMs, playSound }: { delayMs: number; playSound: () => void }) => {
   React.useEffect(() => {
@@ -506,6 +507,17 @@ export const GameBoard: React.FC = () => {
                 ))}
               </div>
             </div>
+
+            {/* Profile panel — shown when player has a Discord account */}
+            {myPlayer?.discordId && (
+              <div className="shrink-0 mb-3">
+                <PlayerProfilePanel
+                  discordId={myPlayer.discordId}
+                  username={myPlayer.username}
+                  avatarUrl={myPlayer.avatarUrl}
+                />
+              </div>
+            )}
 
             {/* Action buttons pinned at bottom */}
             <div className="shrink-0 pt-3 border-t border-white/10 mt-2">

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -24,9 +24,10 @@ export const GameBoard: React.FC = () => {
     gameState,
     gameMessage,
     clearGameMessage,
-    defenseSnapshot,
     suhuhResult,
     clearSuhuhResult,
+    discardedCards,
+    clearDiscardedCards,
     serverTimeOffset,
     updateLobbySettings,
     startLobbyGame,
@@ -42,6 +43,7 @@ export const GameBoard: React.FC = () => {
     playTimerWarning,
     playVictorySound,
     playDefeatSound,
+    playDiscardSound,
   } = useAudio();
   const isDesktop = useIsDesktop();
   const warningPlayedRef = React.useRef(false);
@@ -71,12 +73,19 @@ export const GameBoard: React.FC = () => {
     return () => cancelAnimationFrame(animationFrameId);
   }, [gameState?.phase, gameState?.turnStartTime, gameState?.turnTimeLimit, serverTimeOffset]);
 
-  // Issue #80: drive time-based visibility without calling Date.now() during render
-  const [now, setNow] = React.useState(() => Date.now());
+  // Play discard sound when cards are marked for discard
   React.useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), 250);
-    return () => window.clearInterval(id);
-  }, []);
+    if (discardedCards && discardedCards.length > 0) playDiscardSound();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [discardedCards]);
+
+  // Clear the discard snapshot the moment a new attack is played
+  React.useEffect(() => {
+    if (discardedCards && gameState && gameState.activeAttackCards.length > 0) {
+      clearDiscardedCards();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameState?.activeAttackCards.length]);
 
   // Reset warning flag when the active turn changes
   React.useEffect(() => {
@@ -108,8 +117,6 @@ export const GameBoard: React.FC = () => {
       playVictorySound();
     }
   }, [gameState?.phase, gameState?.loser, room?.sessionId, playVictorySound, playDefeatSound]);
-
-  const defenseVisible = !!defenseSnapshot && now - defenseSnapshot.at < 10000;
 
   if (!room || !gameState) {
     return null;
@@ -207,7 +214,7 @@ export const GameBoard: React.FC = () => {
 
   const isHost = !!gameState.hostId && room.sessionId === gameState.hostId;
 
-  const devSpawnDummies = (difficulty: 'easy' | 'hard' = 'easy') => {
+  const devSpawnDummies = (difficulty: 'easy' | 'hard' | 'dummy' = 'easy') => {
     if (!isHost) return;
     room.send('dev_action', { action: 'spawn_dummies', difficulty });
   };
@@ -255,6 +262,12 @@ export const GameBoard: React.FC = () => {
             <div className="font-bold uppercase tracking-widest border-b border-red-500/50 pb-1 text-red-300">
               Dev Tools
             </div>
+            <button
+              onClick={() => devSpawnDummies('dummy')}
+              className="bg-purple-800 hover:bg-purple-700 px-2 py-1 rounded transition border border-purple-600"
+            >
+              Spawn Dummy
+            </button>
             <button
               onClick={() => devSpawnDummies('easy')}
               className="bg-red-800 hover:bg-red-700 px-2 py-1 rounded transition border border-red-600"
@@ -394,8 +407,16 @@ export const GameBoard: React.FC = () => {
                     Developer
                   </h3>
                   <p className="text-[9px] text-gray-500 leading-snug">
-                    Bots spawn as ready players so you can start a match solo or fill empty seats.
+                    Dummies are manually controlled via the in-game dev panel. Bots play with AI.
                   </p>
+                  <button
+                    type="button"
+                    onClick={() => devSpawnDummies('dummy')}
+                    disabled={!isHost || gameState.players.size >= gameState.maxPlayers}
+                    className="w-full bg-purple-900/55 hover:bg-purple-800/70 disabled:opacity-40 disabled:cursor-not-allowed text-purple-50 text-xs font-bold py-2 px-3 rounded-lg border border-purple-500/40 transition"
+                  >
+                    Spawn dummy (manual control)
+                  </button>
                   <button
                     type="button"
                     onClick={() => devSpawnDummies('easy')}
@@ -669,6 +690,14 @@ export const GameBoard: React.FC = () => {
           </div>
           <button
             type="button"
+            onClick={() => devSpawnDummies('dummy')}
+            disabled={!isHost}
+            className="bg-purple-900/75 hover:bg-purple-800 px-2 py-1.5 rounded-lg transition border border-purple-500/45 font-bold text-left disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Spawn dummy
+          </button>
+          <button
+            type="button"
             onClick={() => devSpawnDummies('easy')}
             disabled={!isHost}
             className="bg-orange-900/75 hover:bg-orange-800 px-2 py-1.5 rounded-lg transition border border-orange-500/45 font-bold text-left disabled:opacity-40 disabled:cursor-not-allowed"
@@ -733,80 +762,126 @@ export const GameBoard: React.FC = () => {
                 </div>
               )}
 
-              {/* Table Pairs */}
+              {/* Table stack — pair-aware: shows atk→def pairing explicitly so mass attack
+                  defenses are obvious. Hidden while the discard overlay is active. */}
               <AnimatePresence>
-                {Array.from({ length: Math.ceil(tableCards.length / 2) }).map((_, pi) => {
-                  const atk = tableCards[pi * 2];
-                  const def = tableCards[pi * 2 + 1];
-                  if (!atk) return null;
-                  return (
-                    <motion.div
-                      key={`tp-${pi}-${atk.suit}-${atk.rank}`}
-                      initial={{ opacity: 0, scale: 0.85 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.7 }}
-                      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-                      className="flex items-center gap-0.5 bg-black/30 p-1 rounded-lg border border-white/5"
-                    >
-                      <UICard card={atk} compact />
-                      <span className="text-[8px] text-gray-500">→</span>
-                      {def ? (
-                        <UICard card={def} compact className="ring-1 ring-green-500/30" />
-                      ) : (
-                        <div className="w-12 h-[72px] rounded-md border border-dashed border-white/20 flex items-center justify-center">
-                          <span className="text-[6px] text-white/30">?</span>
-                        </div>
-                      )}
-                    </motion.div>
-                  );
-                })}
+                {!discardedCards &&
+                  (() => {
+                    // Build pairs from tableStacks (consecutive [atk, def] entries)
+                    type Pair = { atk: SharedCard; def?: SharedCard; pairKey: string };
+                    const pairs: Pair[] = [];
+                    const defSeen = new Set<string>();
+                    for (let i = 0; i < tableCards.length; i += 2) {
+                      const atk = tableCards[i];
+                      if (!atk) continue;
+                      const def = tableCards[i + 1];
+                      // Skip later "pair" entries whose atk is just a previous def
+                      // (chain re-uses def cards as the next round of attackers)
+                      const atkKey = `${atk.suit}:${atk.rank}`;
+                      if (defSeen.has(atkKey)) continue;
+                      if (def) defSeen.add(`${def.suit}:${def.rank}`);
+                      pairs.push({
+                        atk,
+                        def,
+                        pairKey: `${atkKey}-${def ? `${def.suit}:${def.rank}` : 'open'}`,
+                      });
+                    }
+                    // Active attacks not yet attached to any pair — fresh incoming attacks
+                    const pairedKeys = new Set([
+                      ...pairs.map((p) => `${p.atk.suit}:${p.atk.rank}`),
+                      ...pairs.filter((p) => p.def).map((p) => `${p.def!.suit}:${p.def!.rank}`),
+                    ]);
+                    const freshAttacks = attackCards.filter(
+                      (c) => !pairedKeys.has(`${c.suit}:${c.rank}`),
+                    );
+                    // If there are pending pairs (atk played, def not yet), merge fresh attacks into them.
+                    // Otherwise fresh attacks render standalone.
+                    const renderItems: Pair[] = [
+                      ...pairs,
+                      ...freshAttacks.map((atk) => ({
+                        atk,
+                        def: undefined,
+                        pairKey: `fresh-${atk.suit}:${atk.rank}`,
+                      })),
+                    ];
+                    return renderItems.map((p, i) => {
+                      const rotate =
+                        (i % 2 === 0 ? -3 : 3) + (i - (renderItems.length - 1) / 2) * 4;
+                      return (
+                        <motion.div
+                          key={`pair-${p.pairKey}`}
+                          initial={{ opacity: 0, scale: 0.85, y: 12 }}
+                          animate={{ opacity: 1, scale: 1, y: 0, rotate }}
+                          exit={{ opacity: 0, scale: 1, transition: { duration: 0 } }}
+                          transition={{ type: 'spring', stiffness: 300, damping: 24 }}
+                          style={{ zIndex: i }}
+                          className="relative flex-shrink-0"
+                        >
+                          {/* Attacker — underlying card */}
+                          <UICard card={p.atk} compact />
+                          {/* Defender — overlaps the attacker, offset bottom-right, with subtle tilt */}
+                          {p.def && (
+                            <motion.div
+                              initial={{ opacity: 0, x: -6, y: -6, rotate: -8 }}
+                              animate={{ opacity: 1, x: 0, y: 0, rotate: 8 }}
+                              transition={{ type: 'spring', stiffness: 280, damping: 22 }}
+                              className="absolute left-3 top-3 ring-1 ring-green-400/50 rounded-md shadow-[0_2px_8px_rgba(0,0,0,0.4)]"
+                            >
+                              <UICard card={p.def} compact />
+                            </motion.div>
+                          )}
+                        </motion.div>
+                      );
+                    });
+                  })()}
               </AnimatePresence>
 
-              {/* Active Attack Cards */}
+              {/* Discard animation — shown briefly after a successful defense round */}
               <AnimatePresence>
-                {attackCards.map((atk) => (
-                  <motion.div
-                    key={`atk-${atk.suit}-${atk.rank}`}
-                    layoutId={`card-${atk.suit}-${atk.rank}`}
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.75, y: 16 }}
-                    transition={{ type: 'spring', stiffness: 320, damping: 26 }}
-                    className="bg-red-900/30 p-1 rounded-lg border border-red-500/30"
-                  >
-                    <UICard card={atk} compact />
-                    <div className="text-[6px] text-red-400 text-center font-bold animate-pulse">
-                      ATK
-                    </div>
-                  </motion.div>
-                ))}
-              </AnimatePresence>
-
-              {/* Defense Snapshot */}
-              <AnimatePresence>
-                {defenseSnapshot &&
-                  defenseVisible &&
-                  defenseSnapshot.attacking.map((atk, idx) => {
-                    const def = defenseSnapshot.defending[idx];
-                    if (!def) return null;
+                {discardedCards &&
+                  discardedCards.length > 0 &&
+                  (() => {
+                    // Server sends raw tableStacks (each card appears twice in a chain — as the
+                    // def in one pair and the atk in the next) plus activeAttackCards (the latest
+                    // defs again). Dedupe so the discard pile is clean.
+                    const seen = new Set<string>();
+                    const uniqueDiscarded = discardedCards.filter((c) => {
+                      const k = `${c.suit}:${c.rank}`;
+                      if (seen.has(k)) return false;
+                      seen.add(k);
+                      return true;
+                    });
                     return (
                       <motion.div
-                        key={`snap-${idx}-${atk.suit}-${atk.rank}`}
-                        initial={{ opacity: 0, scale: 0.85 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        exit={{ opacity: 0 }}
-                        transition={{ type: 'spring', stiffness: 300, damping: 24 }}
-                        className="relative w-12 h-16"
+                        key="discard-pile"
+                        className="absolute inset-0 flex items-center justify-center pointer-events-none"
                       >
-                        <div className="absolute left-0 top-0">
-                          <UICard card={atk as unknown as SharedCard} compact />
-                        </div>
-                        <div className="absolute left-2 top-2 ring-1 ring-green-400/40 rounded shadow-[0_0_8px_rgba(34,197,94,0.4)]">
-                          <UICard card={def as unknown as SharedCard} compact />
-                        </div>
+                        {uniqueDiscarded.map((card, i) => (
+                          <motion.div
+                            key={`discard-${card.suit}-${card.rank}-${i}`}
+                            initial={{
+                              opacity: 1,
+                              y: 0,
+                              scale: 1,
+                              rotate: (i % 2 === 0 ? -3 : 3) + (i * 1.5 - uniqueDiscarded.length),
+                            }}
+                            animate={{ opacity: 1, y: 0, scale: 1 }}
+                            exit={{
+                              opacity: 0,
+                              y: -55,
+                              scale: 0.45,
+                              rotate: i % 2 === 0 ? -15 : 15,
+                              transition: { duration: 0.38, delay: i * 0.035, ease: 'easeIn' },
+                            }}
+                            style={{ marginLeft: i > 0 ? '-28px' : 0, zIndex: i }}
+                            className="flex-shrink-0"
+                          >
+                            <UICard card={card as unknown as SharedCard} compact />
+                          </motion.div>
+                        ))}
                       </motion.div>
                     );
-                  })}
+                  })()}
               </AnimatePresence>
             </div>
           </div>

--- a/packages/client/src/components/Lobby.tsx
+++ b/packages/client/src/components/Lobby.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useGame } from '../contexts/GameContext';
 import type { RoomAvailable } from 'colyseus.js';
+import { PlayerProfilePanel } from './PlayerProfilePanel';
 
 const getAvailablePlayers = (mode: string) => {
   return mode === 'teams' ? [4, 6] : [2, 3, 4, 5, 6];
@@ -14,7 +15,13 @@ const getAvailableHandSizes = (mode: string, players: number) => {
   }
 };
 
-export const Lobby: React.FC = () => {
+interface LobbyProps {
+  discordId?: string;
+  username?: string;
+  avatarUrl?: string;
+}
+
+export const Lobby: React.FC<LobbyProps> = ({ discordId, username = '', avatarUrl = '' }) => {
   const { createGame, joinGame, spectateGame, findPublicGames, error } = useGame();
 
   const [rooms, setRooms] = useState<RoomAvailable[]>([]);
@@ -57,12 +64,18 @@ export const Lobby: React.FC = () => {
     e.preventDefault();
     if (!joinCode.trim()) return;
     setIsLoading(true);
-    await joinGame(joinCode.trim());
+    await joinGame(joinCode.trim(), discordId);
     setIsLoading(false);
   };
 
   return (
     <div className="max-w-4xl mx-auto w-full grid grid-cols-1 md:grid-cols-2 gap-8 text-black relative z-20">
+      {/* Profile panel spans full width when discordId is available */}
+      {discordId && (
+        <div className="col-span-full">
+          <PlayerProfilePanel discordId={discordId} username={username} avatarUrl={avatarUrl} />
+        </div>
+      )}
       {/* Create Room Panel */}
       <div className="bg-green-100 p-8 rounded-xl shadow-lg border border-green-300">
         <h2 className="text-2xl font-bold text-green-900 mb-6">Create New Game</h2>
@@ -243,7 +256,7 @@ export const Lobby: React.FC = () => {
                       </div>
                       <div className="flex gap-2">
                         <button
-                          onClick={() => joinGame(r.roomId)}
+                          onClick={() => joinGame(r.roomId, discordId)}
                           disabled={isLoading || isFull}
                           className="bg-green-100 text-green-800 hover:bg-green-200 font-bold px-4 py-2 rounded text-sm transition disabled:opacity-50"
                         >

--- a/packages/client/src/components/Lobby.tsx
+++ b/packages/client/src/components/Lobby.tsx
@@ -3,7 +3,6 @@ import { useGame } from '../contexts/GameContext';
 import type { RoomAvailable } from 'colyseus.js';
 import { PlayerProfilePanel } from './PlayerProfilePanel';
 import { LoginPanel } from './LoginPanel';
-import { useAuth } from '../contexts/AuthContext';
 
 const getAvailablePlayers = (mode: string) => {
   return mode === 'teams' ? [4, 6] : [2, 3, 4, 5, 6];
@@ -18,25 +17,19 @@ const getAvailableHandSizes = (mode: string, players: number) => {
 };
 
 interface LobbyProps {
-  // These props carry the Discord Activity SDK identity (embedded mode).
-  // In browser mode the identity comes from AuthContext instead.
   discordId?: string;
+  userId?: string;
   username?: string;
   avatarUrl?: string;
 }
 
 export const Lobby: React.FC<LobbyProps> = ({
-  discordId: sdkDiscordId,
-  username: sdkUsername,
-  avatarUrl: sdkAvatarUrl,
+  discordId,
+  userId,
+  username = '',
+  avatarUrl = '',
 }) => {
   const { createGame, joinGame, spectateGame, findPublicGames, error } = useGame();
-  const { user: browserUser } = useAuth();
-
-  // Browser OAuth takes precedence over empty SDK props; SDK props win when embedded
-  const discordId = sdkDiscordId ?? browserUser?.id;
-  const username = sdkUsername ?? browserUser?.globalName ?? browserUser?.username ?? '';
-  const avatarUrl = sdkAvatarUrl ?? browserUser?.avatarUrl ?? '';
 
   const [rooms, setRooms] = useState<RoomAvailable[]>([]);
   const [joinCode, setJoinCode] = useState('');
@@ -78,7 +71,7 @@ export const Lobby: React.FC<LobbyProps> = ({
     e.preventDefault();
     if (!joinCode.trim()) return;
     setIsLoading(true);
-    await joinGame(joinCode.trim(), discordId);
+    await joinGame(joinCode.trim(), discordId, userId);
     setIsLoading(false);
   };
 
@@ -201,8 +194,13 @@ export const Lobby: React.FC<LobbyProps> = ({
         <LoginPanel />
 
         {/* Expanded profile stats when logged in */}
-        {discordId && (
-          <PlayerProfilePanel discordId={discordId} username={username} avatarUrl={avatarUrl} />
+        {(discordId || userId) && (
+          <PlayerProfilePanel
+            discordId={discordId}
+            userId={userId}
+            username={username}
+            avatarUrl={avatarUrl}
+          />
         )}
 
         {/* Join by Code */}
@@ -272,7 +270,7 @@ export const Lobby: React.FC<LobbyProps> = ({
                       </div>
                       <div className="flex gap-2">
                         <button
-                          onClick={() => joinGame(r.roomId, discordId)}
+                          onClick={() => joinGame(r.roomId, discordId, userId)}
                           disabled={isLoading || isFull}
                           className="bg-green-100 text-green-800 hover:bg-green-200 font-bold px-4 py-2 rounded text-sm transition disabled:opacity-50"
                         >

--- a/packages/client/src/components/Lobby.tsx
+++ b/packages/client/src/components/Lobby.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useGame } from '../contexts/GameContext';
 import type { RoomAvailable } from 'colyseus.js';
 import { PlayerProfilePanel } from './PlayerProfilePanel';
+import { LoginPanel } from './LoginPanel';
+import { useAuth } from '../contexts/AuthContext';
 
 const getAvailablePlayers = (mode: string) => {
   return mode === 'teams' ? [4, 6] : [2, 3, 4, 5, 6];
@@ -16,13 +18,25 @@ const getAvailableHandSizes = (mode: string, players: number) => {
 };
 
 interface LobbyProps {
+  // These props carry the Discord Activity SDK identity (embedded mode).
+  // In browser mode the identity comes from AuthContext instead.
   discordId?: string;
   username?: string;
   avatarUrl?: string;
 }
 
-export const Lobby: React.FC<LobbyProps> = ({ discordId, username = '', avatarUrl = '' }) => {
+export const Lobby: React.FC<LobbyProps> = ({
+  discordId: sdkDiscordId,
+  username: sdkUsername,
+  avatarUrl: sdkAvatarUrl,
+}) => {
   const { createGame, joinGame, spectateGame, findPublicGames, error } = useGame();
+  const { user: browserUser } = useAuth();
+
+  // Browser OAuth takes precedence over empty SDK props; SDK props win when embedded
+  const discordId = sdkDiscordId ?? browserUser?.id;
+  const username = sdkUsername ?? browserUser?.globalName ?? browserUser?.username ?? '';
+  const avatarUrl = sdkAvatarUrl ?? browserUser?.avatarUrl ?? '';
 
   const [rooms, setRooms] = useState<RoomAvailable[]>([]);
   const [joinCode, setJoinCode] = useState('');
@@ -70,12 +84,6 @@ export const Lobby: React.FC<LobbyProps> = ({ discordId, username = '', avatarUr
 
   return (
     <div className="max-w-4xl mx-auto w-full grid grid-cols-1 md:grid-cols-2 gap-8 text-black relative z-20">
-      {/* Profile panel spans full width when discordId is available */}
-      {discordId && (
-        <div className="col-span-full">
-          <PlayerProfilePanel discordId={discordId} username={username} avatarUrl={avatarUrl} />
-        </div>
-      )}
       {/* Create Room Panel */}
       <div className="bg-green-100 p-8 rounded-xl shadow-lg border border-green-300">
         <h2 className="text-2xl font-bold text-green-900 mb-6">Create New Game</h2>
@@ -187,8 +195,16 @@ export const Lobby: React.FC<LobbyProps> = ({ discordId, username = '', avatarUr
         </form>
       </div>
 
-      {/* Join Room Panel */}
+      {/* Right column: auth/profile + join + public rooms */}
       <div className="flex flex-col space-y-6">
+        {/* Login / profile panel — always shown in browser mode */}
+        <LoginPanel />
+
+        {/* Expanded profile stats when logged in */}
+        {discordId && (
+          <PlayerProfilePanel discordId={discordId} username={username} avatarUrl={avatarUrl} />
+        )}
+
         {/* Join by Code */}
         <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-200">
           <h2 className="text-xl font-bold text-gray-800 mb-4">Join Private Game</h2>

--- a/packages/client/src/components/LoginPanel.tsx
+++ b/packages/client/src/components/LoginPanel.tsx
@@ -1,38 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 
 const DiscordLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" aria-hidden>
+  <svg viewBox="0 0 24 24" className="w-4 h-4 fill-current shrink-0" aria-hidden>
     <path d="M20.317 4.37a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
   </svg>
 );
 
-export const LoginPanel: React.FC = () => {
-  const { user, isLoading, loginWithDiscord, logout } = useAuth();
+type Tab = 'login' | 'register';
 
-  if (isLoading) {
-    return (
-      <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-5 flex items-center justify-center gap-3 text-indigo-300 text-sm">
-        <div className="w-4 h-4 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin" />
-        Connecting to Discord…
-      </div>
-    );
-  }
+export const LoginPanel: React.FC = () => {
+  const { user, isLoading, error, loginWithDiscord, loginWithEmail, register, logout } = useAuth();
+  const [tab, setTab] = useState<Tab>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
 
   if (user) {
     return (
       <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-4 flex items-center justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
-          <img
-            src={user.avatarUrl}
-            alt={user.username}
-            className="w-9 h-9 rounded-full border-2 border-indigo-400 shrink-0"
-          />
+          {user.avatarUrl ? (
+            <img
+              src={user.avatarUrl}
+              alt={user.username}
+              className="w-9 h-9 rounded-full border-2 border-indigo-400 shrink-0"
+            />
+          ) : (
+            <div className="w-9 h-9 rounded-full bg-indigo-700 flex items-center justify-center font-bold text-sm border-2 border-indigo-400 shrink-0">
+              {user.username.charAt(0).toUpperCase()}
+            </div>
+          )}
           <div className="min-w-0">
             <div className="font-bold text-sm text-white truncate">
               {user.globalName || user.username}
             </div>
-            <div className="text-indigo-400 text-xs">Logged in with Discord</div>
+            <div className="text-indigo-400 text-xs capitalize">{user.method} account</div>
           </div>
         </div>
         <button
@@ -45,20 +49,107 @@ export const LoginPanel: React.FC = () => {
     );
   }
 
+  const displayError = localError || error;
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    try {
+      if (tab === 'login') {
+        await loginWithEmail(email, password);
+      } else {
+        if (!username.trim()) {
+          setLocalError('Username is required');
+          return;
+        }
+        await register(email, password, username);
+      }
+    } catch {
+      // error already set in context
+    }
+  };
+
   return (
     <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-5">
-      <div className="text-white font-bold mb-1">Your Account</div>
-      <p className="text-indigo-300 text-xs mb-4">
-        Log in with Discord to track your stats and match history. Guests can still play — no
-        account required.
-      </p>
+      <div className="text-white font-bold mb-3">Your Account</div>
+
+      {/* Auth method tabs */}
+      <div className="flex gap-2 mb-4">
+        {(['login', 'register'] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => {
+              setTab(t);
+              setLocalError(null);
+            }}
+            className={`px-3 py-1 rounded text-xs font-semibold capitalize transition ${
+              tab === t
+                ? 'bg-indigo-600 text-white'
+                : 'bg-indigo-900 text-indigo-300 hover:bg-indigo-800'
+            }`}
+          >
+            {t === 'login' ? 'Log In' : 'Register'}
+          </button>
+        ))}
+      </div>
+
+      {/* Discord button */}
       <button
         onClick={loginWithDiscord}
-        className="w-full flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-500 text-white font-bold py-2.5 px-4 rounded-lg transition"
+        disabled={isLoading}
+        className="w-full flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white font-semibold py-2.5 px-4 rounded-lg transition mb-3"
       >
         <DiscordLogo />
-        Login with Discord
+        Continue with Discord
       </button>
+
+      <div className="flex items-center gap-2 mb-3">
+        <div className="flex-1 h-px bg-indigo-800" />
+        <span className="text-indigo-500 text-xs">or</span>
+        <div className="flex-1 h-px bg-indigo-800" />
+      </div>
+
+      {/* Email/password form */}
+      <form onSubmit={handleEmailSubmit} className="space-y-2">
+        {tab === 'register' && (
+          <input
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full bg-indigo-900 border border-indigo-700 text-white placeholder-indigo-500 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-indigo-400"
+            maxLength={32}
+          />
+        )}
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full bg-indigo-900 border border-indigo-700 text-white placeholder-indigo-500 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-indigo-400"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full bg-indigo-900 border border-indigo-700 text-white placeholder-indigo-500 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-indigo-400"
+        />
+
+        {displayError && <p className="text-red-400 text-xs">{displayError}</p>}
+
+        <button
+          type="submit"
+          disabled={isLoading || !email || !password}
+          className="w-full bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white font-bold py-2.5 rounded-lg transition"
+        >
+          {isLoading ? 'Loading…' : tab === 'login' ? 'Log In' : 'Create Account'}
+        </button>
+      </form>
+
+      <p className="text-indigo-500 text-xs mt-3 text-center">
+        Guests can play without an account — login is optional.
+      </p>
     </div>
   );
 };

--- a/packages/client/src/components/LoginPanel.tsx
+++ b/packages/client/src/components/LoginPanel.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+const DiscordLogo = () => (
+  <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" aria-hidden>
+    <path d="M20.317 4.37a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+  </svg>
+);
+
+export const LoginPanel: React.FC = () => {
+  const { user, isLoading, loginWithDiscord, logout } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-5 flex items-center justify-center gap-3 text-indigo-300 text-sm">
+        <div className="w-4 h-4 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin" />
+        Connecting to Discord…
+      </div>
+    );
+  }
+
+  if (user) {
+    return (
+      <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <img
+            src={user.avatarUrl}
+            alt={user.username}
+            className="w-9 h-9 rounded-full border-2 border-indigo-400 shrink-0"
+          />
+          <div className="min-w-0">
+            <div className="font-bold text-sm text-white truncate">
+              {user.globalName || user.username}
+            </div>
+            <div className="text-indigo-400 text-xs">Logged in with Discord</div>
+          </div>
+        </div>
+        <button
+          onClick={logout}
+          className="text-indigo-400 hover:text-white text-xs px-2 py-1 rounded border border-indigo-700 hover:border-indigo-500 transition shrink-0"
+        >
+          Log out
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-5">
+      <div className="text-white font-bold mb-1">Your Account</div>
+      <p className="text-indigo-300 text-xs mb-4">
+        Log in with Discord to track your stats and match history. Guests can still play — no
+        account required.
+      </p>
+      <button
+        onClick={loginWithDiscord}
+        className="w-full flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-500 text-white font-bold py-2.5 px-4 rounded-lg transition"
+      >
+        <DiscordLogo />
+        Login with Discord
+      </button>
+    </div>
+  );
+};

--- a/packages/client/src/components/PlayerProfilePanel.tsx
+++ b/packages/client/src/components/PlayerProfilePanel.tsx
@@ -26,26 +26,31 @@ interface MatchRecord {
 }
 
 interface Props {
-  discordId: string;
+  discordId?: string;
+  userId?: string;
   avatarUrl: string;
   username: string;
 }
 
 const API = '/api';
 
-export const PlayerProfilePanel: React.FC<Props> = ({ discordId, avatarUrl, username }) => {
+export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarUrl, username }) => {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [history, setHistory] = useState<MatchRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<'stats' | 'history'>('stats');
 
+  const id = discordId ?? userId ?? '';
+  const byParam = userId && !discordId ? '&by=user' : '';
+
   useEffect(() => {
+    if (!id) return;
     let cancelled = false;
     setLoading(true);
 
     Promise.all([
-      fetch(`${API}/profile/${discordId}`).then((r) => (r.ok ? r.json() : null)),
-      fetch(`${API}/history/${discordId}?limit=10`).then((r) => (r.ok ? r.json() : [])),
+      fetch(`${API}/profile/${id}?${byParam.slice(1)}`).then((r) => (r.ok ? r.json() : null)),
+      fetch(`${API}/history/${id}?limit=10${byParam}`).then((r) => (r.ok ? r.json() : [])),
     ])
       .then(([prof, hist]) => {
         if (cancelled) return;
@@ -122,7 +127,7 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, avatarUrl, user
           </div>
         )
       ) : (
-        <HistoryList history={history} discordId={discordId} />
+        <HistoryList history={history} playerId={id} />
       )}
     </div>
   );
@@ -144,9 +149,9 @@ const StatCard: React.FC<{
   </div>
 );
 
-const HistoryList: React.FC<{ history: MatchRecord[]; discordId: string }> = ({
+const HistoryList: React.FC<{ history: MatchRecord[]; playerId: string }> = ({
   history,
-  discordId,
+  playerId,
 }) => {
   if (history.length === 0) {
     return <div className="text-indigo-400 text-sm text-center py-4">No match history yet.</div>;
@@ -155,8 +160,8 @@ const HistoryList: React.FC<{ history: MatchRecord[]; discordId: string }> = ({
   return (
     <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
       {history.map((m) => {
-        const won = m.winners.includes(discordId);
-        const wasDurak = m.durak === discordId;
+        const won = m.winners.includes(playerId);
+        const wasDurak = m.durak === playerId;
         const result = won ? 'Win' : wasDurak ? 'Durak' : 'Loss';
         const resultColor = won ? 'text-green-400' : wasDurak ? 'text-red-400' : 'text-yellow-400';
         const date = new Date(m.date).toLocaleDateString(undefined, {

--- a/packages/client/src/components/PlayerProfilePanel.tsx
+++ b/packages/client/src/components/PlayerProfilePanel.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from 'react';
+
+interface ProfileStats {
+  gamesPlayed: number;
+  wins: number;
+  losses: number;
+  durakCount: number;
+}
+
+interface Profile {
+  discordId: string;
+  username: string;
+  avatarUrl: string;
+  stats: ProfileStats;
+  updatedAt: string;
+}
+
+interface MatchRecord {
+  _id: string;
+  roomId: string;
+  date: string;
+  mode: string;
+  discordIds: string[];
+  winners: string[];
+  durak: string | null;
+}
+
+interface Props {
+  discordId: string;
+  avatarUrl: string;
+  username: string;
+}
+
+const API = '/api';
+
+export const PlayerProfilePanel: React.FC<Props> = ({ discordId, avatarUrl, username }) => {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [history, setHistory] = useState<MatchRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<'stats' | 'history'>('stats');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.all([
+      fetch(`${API}/profile/${discordId}`).then((r) => (r.ok ? r.json() : null)),
+      fetch(`${API}/history/${discordId}?limit=10`).then((r) => (r.ok ? r.json() : [])),
+    ])
+      .then(([prof, hist]) => {
+        if (cancelled) return;
+        setProfile(prof);
+        setHistory(Array.isArray(hist) ? hist : []);
+      })
+      .catch(() => {
+        if (!cancelled) setHistory([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [discordId]);
+
+  const stats = profile?.stats;
+  const winRate =
+    stats && stats.gamesPlayed > 0 ? Math.round((stats.wins / stats.gamesPlayed) * 100) : 0;
+
+  return (
+    <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-5 text-white">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-4">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={username}
+            className="w-12 h-12 rounded-full border-2 border-indigo-400"
+          />
+        ) : (
+          <div className="w-12 h-12 rounded-full bg-indigo-700 flex items-center justify-center text-xl font-bold border-2 border-indigo-400">
+            {username.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div>
+          <div className="font-bold text-lg leading-tight">{username}</div>
+          <div className="text-indigo-400 text-xs">Discord Player</div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-2 mb-4">
+        {(['stats', 'history'] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-1 rounded text-xs font-semibold capitalize transition ${
+              tab === t
+                ? 'bg-indigo-600 text-white'
+                : 'bg-indigo-900 text-indigo-300 hover:bg-indigo-800'
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="text-indigo-400 text-sm text-center py-4 animate-pulse">Loading...</div>
+      ) : tab === 'stats' ? (
+        stats ? (
+          <div className="grid grid-cols-2 gap-3">
+            <StatCard label="Games Played" value={stats.gamesPlayed} />
+            <StatCard label="Win Rate" value={`${winRate}%`} highlight={winRate >= 50} />
+            <StatCard label="Wins" value={stats.wins} highlight />
+            <StatCard label="Durak" value={stats.durakCount} dim />
+          </div>
+        ) : (
+          <div className="text-indigo-400 text-sm text-center py-4">
+            No stats yet — play a game to get started.
+          </div>
+        )
+      ) : (
+        <HistoryList history={history} discordId={discordId} />
+      )}
+    </div>
+  );
+};
+
+const StatCard: React.FC<{
+  label: string;
+  value: number | string;
+  highlight?: boolean;
+  dim?: boolean;
+}> = ({ label, value, highlight, dim }) => (
+  <div className="bg-indigo-900/60 rounded-lg p-3 text-center">
+    <div
+      className={`text-2xl font-bold ${highlight ? 'text-green-400' : dim ? 'text-red-400' : 'text-white'}`}
+    >
+      {value}
+    </div>
+    <div className="text-indigo-400 text-xs mt-1">{label}</div>
+  </div>
+);
+
+const HistoryList: React.FC<{ history: MatchRecord[]; discordId: string }> = ({
+  history,
+  discordId,
+}) => {
+  if (history.length === 0) {
+    return <div className="text-indigo-400 text-sm text-center py-4">No match history yet.</div>;
+  }
+
+  return (
+    <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+      {history.map((m) => {
+        const won = m.winners.includes(discordId);
+        const wasDurak = m.durak === discordId;
+        const result = won ? 'Win' : wasDurak ? 'Durak' : 'Loss';
+        const resultColor = won ? 'text-green-400' : wasDurak ? 'text-red-400' : 'text-yellow-400';
+        const date = new Date(m.date).toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+        });
+
+        return (
+          <div
+            key={m._id}
+            className="flex items-center justify-between bg-indigo-900/50 rounded px-3 py-2 text-xs"
+          >
+            <div className="flex items-center gap-2">
+              <span className={`font-bold ${resultColor}`}>{result}</span>
+              <span className="text-indigo-400 capitalize">{m.mode}</span>
+            </div>
+            <div className="text-indigo-500">{date}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/client/src/components/PlayerProfilePanel.tsx
+++ b/packages/client/src/components/PlayerProfilePanel.tsx
@@ -46,6 +46,7 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarU
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
 
     Promise.all([

--- a/packages/client/src/contexts/AuthContext.tsx
+++ b/packages/client/src/contexts/AuthContext.tsx
@@ -1,0 +1,118 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+const CLIENT_ID = import.meta.env.VITE_DISCORD_CLIENT_ID || '123456789012345678';
+const STORAGE_KEY = 'durak_discord_auth';
+// Use current origin so it works in dev (5173) and prod alike
+const REDIRECT_URI = `${window.location.origin}/auth/callback`;
+
+export interface DiscordUser {
+  id: string;
+  username: string;
+  globalName: string | null;
+  avatarUrl: string;
+  accessToken: string;
+}
+
+interface AuthContextState {
+  user: DiscordUser | null;
+  isLoading: boolean;
+  loginWithDiscord: () => void;
+  logout: () => void;
+  handleOAuthCallback: (code: string) => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextState>({
+  user: null,
+  isLoading: false,
+  loginWithDiscord: () => {},
+  logout: () => {},
+  handleOAuthCallback: async () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+function buildAvatarUrl(id: string, hash: string | null): string {
+  if (hash) return `https://cdn.discordapp.com/avatars/${id}/${hash}.png?size=128`;
+  return `https://cdn.discordapp.com/embed/avatars/${parseInt(id || '0') % 5}.png`;
+}
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<DiscordUser | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Restore saved session on mount
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        setUser(JSON.parse(saved));
+      } catch {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+  }, []);
+
+  const persist = (u: DiscordUser | null) => {
+    if (u) localStorage.setItem(STORAGE_KEY, JSON.stringify(u));
+    else localStorage.removeItem(STORAGE_KEY);
+    setUser(u);
+  };
+
+  const loginWithDiscord = useCallback(() => {
+    const params = new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      response_type: 'code',
+      scope: 'identify',
+    });
+    window.location.href = `https://discord.com/api/oauth2/authorize?${params}`;
+  }, []);
+
+  const handleOAuthCallback = useCallback(async (code: string) => {
+    setIsLoading(true);
+    try {
+      // Exchange code for access token via our server (keeps client secret server-side)
+      const tokenRes = await fetch('/api/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, redirect_uri: REDIRECT_URI }),
+      });
+      if (!tokenRes.ok) throw new Error('Token exchange failed');
+      const { access_token } = await tokenRes.json();
+
+      // Fetch Discord user info
+      const meRes = await fetch('https://discord.com/api/users/@me', {
+        headers: { Authorization: `Bearer ${access_token}` },
+      });
+      if (!meRes.ok) throw new Error('Failed to fetch Discord user');
+      const me = await meRes.json();
+
+      persist({
+        id: me.id,
+        username: me.username,
+        globalName: me.global_name ?? null,
+        avatarUrl: buildAvatarUrl(me.id, me.avatar),
+        accessToken: access_token,
+      });
+
+      // Remove OAuth params from URL without triggering a reload
+      window.history.replaceState({}, '', window.location.pathname);
+    } catch (e) {
+      console.error('Discord OAuth failed:', e);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    persist(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{ user, isLoading, loginWithDiscord, logout, handleOAuthCallback }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/packages/client/src/contexts/AuthContext.tsx
+++ b/packages/client/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useCallback } from 'react';
 
 const CLIENT_ID = import.meta.env.VITE_DISCORD_CLIENT_ID || '123456789012345678';
 const STORAGE_KEY = 'durak_auth';
@@ -38,6 +38,7 @@ const AuthContext = createContext<AuthContextState>({
   handleOAuthCallback: async () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => useContext(AuthContext);
 
 function buildAvatarUrl(id: string, hash: string | null): string {
@@ -46,20 +47,19 @@ function buildAvatarUrl(id: string, hash: string | null): string {
 }
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
+  const [user, setUser] = useState<AuthUser | null>(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
       try {
-        setUser(JSON.parse(saved));
+        return JSON.parse(saved) as AuthUser;
       } catch {
         localStorage.removeItem(STORAGE_KEY);
       }
     }
-  }, []);
+    return null;
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const persist = (u: AuthUser | null) => {
     if (u) localStorage.setItem(STORAGE_KEY, JSON.stringify(u));
@@ -105,8 +105,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       });
 
       window.history.replaceState({}, '', window.location.pathname);
-    } catch (e: any) {
-      setError(e.message || 'Discord login failed');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Discord login failed');
     } finally {
       setIsLoading(false);
     }
@@ -133,8 +133,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         email: data.user.email,
         token: data.token,
       });
-    } catch (e: any) {
-      setError(e.message || 'Login failed');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Login failed');
       throw e;
     } finally {
       setIsLoading(false);
@@ -162,8 +162,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         email: data.user.email,
         token: data.token,
       });
-    } catch (e: any) {
-      setError(e.message || 'Registration failed');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Registration failed');
       throw e;
     } finally {
       setIsLoading(false);

--- a/packages/client/src/contexts/AuthContext.tsx
+++ b/packages/client/src/contexts/AuthContext.tsx
@@ -1,22 +1,28 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 
 const CLIENT_ID = import.meta.env.VITE_DISCORD_CLIENT_ID || '123456789012345678';
-const STORAGE_KEY = 'durak_discord_auth';
-// Use current origin so it works in dev (5173) and prod alike
+const STORAGE_KEY = 'durak_auth';
 const REDIRECT_URI = `${window.location.origin}/auth/callback`;
 
-export interface DiscordUser {
-  id: string;
+export type AuthMethod = 'discord' | 'email';
+
+export interface AuthUser {
+  id: string; // discordId for Discord users, MongoDB _id for email users
+  method: AuthMethod;
   username: string;
   globalName: string | null;
   avatarUrl: string;
-  accessToken: string;
+  email?: string;
+  token?: string; // JWT for email users
 }
 
 interface AuthContextState {
-  user: DiscordUser | null;
+  user: AuthUser | null;
   isLoading: boolean;
+  error: string | null;
   loginWithDiscord: () => void;
+  loginWithEmail: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, username: string) => Promise<void>;
   logout: () => void;
   handleOAuthCallback: (code: string) => Promise<void>;
 }
@@ -24,7 +30,10 @@ interface AuthContextState {
 const AuthContext = createContext<AuthContextState>({
   user: null,
   isLoading: false,
+  error: null,
   loginWithDiscord: () => {},
+  loginWithEmail: async () => {},
+  register: async () => {},
   logout: () => {},
   handleOAuthCallback: async () => {},
 });
@@ -37,10 +46,10 @@ function buildAvatarUrl(id: string, hash: string | null): string {
 }
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<DiscordUser | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  // Restore saved session on mount
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
@@ -52,7 +61,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
-  const persist = (u: DiscordUser | null) => {
+  const persist = (u: AuthUser | null) => {
     if (u) localStorage.setItem(STORAGE_KEY, JSON.stringify(u));
     else localStorage.removeItem(STORAGE_KEY);
     setUser(u);
@@ -70,8 +79,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const handleOAuthCallback = useCallback(async (code: string) => {
     setIsLoading(true);
+    setError(null);
     try {
-      // Exchange code for access token via our server (keeps client secret server-side)
       const tokenRes = await fetch('/api/token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -80,7 +89,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (!tokenRes.ok) throw new Error('Token exchange failed');
       const { access_token } = await tokenRes.json();
 
-      // Fetch Discord user info
       const meRes = await fetch('https://discord.com/api/users/@me', {
         headers: { Authorization: `Bearer ${access_token}` },
       });
@@ -89,16 +97,74 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       persist({
         id: me.id,
+        method: 'discord',
         username: me.username,
         globalName: me.global_name ?? null,
         avatarUrl: buildAvatarUrl(me.id, me.avatar),
-        accessToken: access_token,
+        token: access_token,
       });
 
-      // Remove OAuth params from URL without triggering a reload
       window.history.replaceState({}, '', window.location.pathname);
-    } catch (e) {
-      console.error('Discord OAuth failed:', e);
+    } catch (e: any) {
+      setError(e.message || 'Discord login failed');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const loginWithEmail = useCallback(async (email: string, password: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Login failed');
+
+      persist({
+        id: data.user.id,
+        method: 'email',
+        username: data.user.username,
+        globalName: null,
+        avatarUrl: data.user.avatarUrl || '',
+        email: data.user.email,
+        token: data.token,
+      });
+    } catch (e: any) {
+      setError(e.message || 'Login failed');
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const register = useCallback(async (email: string, password: string, username: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, username }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Registration failed');
+
+      persist({
+        id: data.user.id,
+        method: 'email',
+        username: data.user.username,
+        globalName: null,
+        avatarUrl: data.user.avatarUrl || '',
+        email: data.user.email,
+        token: data.token,
+      });
+    } catch (e: any) {
+      setError(e.message || 'Registration failed');
+      throw e;
     } finally {
       setIsLoading(false);
     }
@@ -106,11 +172,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const logout = useCallback(() => {
     persist(null);
+    setError(null);
   }, []);
 
   return (
     <AuthContext.Provider
-      value={{ user, isLoading, loginWithDiscord, logout, handleOAuthCallback }}
+      value={{
+        user,
+        isLoading,
+        error,
+        loginWithDiscord,
+        loginWithEmail,
+        register,
+        logout,
+        handleOAuthCallback,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -34,11 +34,16 @@ interface GameContextState {
   discardedCards: DiscardedCard[] | null;
   clearDiscardedCards: () => void;
   createGame: (options: Record<string, unknown>) => Promise<void>;
-  joinGame: (roomId: string) => Promise<void>;
+  joinGame: (roomId: string, discordId?: string) => Promise<void>;
   spectateGame: (roomId: string) => Promise<void>;
   findPublicGames: () => Promise<RoomAvailable[]>;
   leaveGame: () => void;
-  autoJoinDiscordRoom: (instanceId: string, username: string, avatarUrl: string) => Promise<void>;
+  autoJoinDiscordRoom: (
+    instanceId: string,
+    username: string,
+    avatarUrl: string,
+    discordId?: string,
+  ) => Promise<void>;
   updateLobbySettings: (settings: Partial<GameState>) => void;
   startLobbyGame: () => void;
   serverTimeOffset: number;
@@ -267,9 +272,9 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const joinGame = async (roomId: string) => {
+  const joinGame = async (roomId: string, discordId?: string) => {
     try {
-      const roomInstance = await client.joinById<GameState>(roomId);
+      const roomInstance = await client.joinById<GameState>(roomId, discordId ? { discordId } : {});
       handleRoomEvents(roomInstance);
     } catch (e: unknown) {
       console.error('Error joining room:', e);
@@ -296,12 +301,14 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     discordInstanceId: string,
     username: string,
     avatarUrl: string,
+    discordId?: string,
   ) => {
     try {
       const roomInstance = await client.joinOrCreate<GameState>('durak', {
         discordInstanceId,
         username,
         avatarUrl,
+        ...(discordId ? { discordId } : {}),
       });
       handleRoomEvents(roomInstance);
     } catch (e: unknown) {

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -12,6 +12,7 @@ type DefenseSnapshot = {
 
 export type SuhuhDraw = { playerId: string; suit: string; rank: number; isJoker: boolean };
 export type SuhuhResult = { draws: SuhuhDraw[]; winnerId: string } | null;
+export type DiscardedCard = { suit: string; rank: number; isJoker: boolean };
 
 const RECONNECT_TOKEN_KEY = 'durak_reconnection_token';
 const MAX_RECONNECT_ATTEMPTS = 3;
@@ -30,6 +31,8 @@ interface GameContextState {
   defenseSnapshot: DefenseSnapshot;
   suhuhResult: SuhuhResult;
   clearSuhuhResult: () => void;
+  discardedCards: DiscardedCard[] | null;
+  clearDiscardedCards: () => void;
   createGame: (options: Record<string, unknown>) => Promise<void>;
   joinGame: (roomId: string) => Promise<void>;
   spectateGame: (roomId: string) => Promise<void>;
@@ -54,6 +57,8 @@ const GameContext = createContext<GameContextState>({
   defenseSnapshot: null,
   suhuhResult: null,
   clearSuhuhResult: () => {},
+  discardedCards: null,
+  clearDiscardedCards: () => {},
   createGame: async () => {},
   joinGame: async () => {},
   spectateGame: async () => {},
@@ -98,6 +103,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [isSpectator, setIsSpectator] = useState(false);
   const [defenseSnapshot, setDefenseSnapshot] = useState<DefenseSnapshot>(null);
   const [suhuhResult, setSuhuhResult] = useState<SuhuhResult>(null);
+  const [discardedCards, setDiscardedCards] = useState<DiscardedCard[] | null>(null);
+  const discardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [serverTimeOffset, setServerTimeOffset] = useState<number>(0);
   // Colyseus mutates state in place, so we need a manual tick to trigger React updates
   const [, setTick] = useState(0);
@@ -117,6 +124,10 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const clearGameMessage = () => setGameMessage(null);
   const clearSuhuhResult = () => setSuhuhResult(null);
+  const clearDiscardedCards = () => {
+    if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
+    setDiscardedCards(null);
+  };
 
   const attemptReconnect = async () => {
     const token = sessionStorage.getItem(RECONNECT_TOKEN_KEY);
@@ -173,6 +184,12 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     roomInstance.onMessage('clearDefenseSnapshot', () => {
       setDefenseSnapshot(null);
+    });
+
+    roomInstance.onMessage('roundDiscarded', (data: { cards: DiscardedCard[] }) => {
+      if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
+      setDiscardedCards(data.cards);
+      discardTimerRef.current = setTimeout(() => setDiscardedCards(null), 2500);
     });
 
     roomInstance.onMessage('suhuhResult', (data: { draws: SuhuhDraw[]; winnerId: string }) => {
@@ -342,6 +359,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         defenseSnapshot,
         suhuhResult,
         clearSuhuhResult,
+        discardedCards,
+        clearDiscardedCards,
         createGame,
         joinGame,
         spectateGame,

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -34,7 +34,7 @@ interface GameContextState {
   discardedCards: DiscardedCard[] | null;
   clearDiscardedCards: () => void;
   createGame: (options: Record<string, unknown>) => Promise<void>;
-  joinGame: (roomId: string, discordId?: string) => Promise<void>;
+  joinGame: (roomId: string, discordId?: string, userId?: string) => Promise<void>;
   spectateGame: (roomId: string) => Promise<void>;
   findPublicGames: () => Promise<RoomAvailable[]>;
   leaveGame: () => void;
@@ -272,9 +272,12 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const joinGame = async (roomId: string, discordId?: string) => {
+  const joinGame = async (roomId: string, discordId?: string, userId?: string) => {
     try {
-      const roomInstance = await client.joinById<GameState>(roomId, discordId ? { discordId } : {});
+      const opts: Record<string, string> = {};
+      if (discordId) opts.discordId = discordId;
+      if (userId) opts.userId = userId;
+      const roomInstance = await client.joinById<GameState>(roomId, opts);
       handleRoomEvents(roomInstance);
     } catch (e: unknown) {
       console.error('Error joining room:', e);

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 import { GameProvider } from './contexts/GameContext.tsx';
+import { AuthProvider } from './contexts/AuthContext.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <GameProvider>
-      <App />
-    </GameProvider>
+    <AuthProvider>
+      <GameProvider>
+        <App />
+      </GameProvider>
+    </AuthProvider>
   </StrictMode>,
 );

--- a/packages/client/src/test/Lobby.test.tsx
+++ b/packages/client/src/test/Lobby.test.tsx
@@ -19,6 +19,8 @@ function mockGameContext(overrides: Partial<ReturnType<typeof GameContextModule.
     defenseSnapshot: null,
     suhuhResult: null,
     clearSuhuhResult: vi.fn(),
+    discardedCards: null,
+    clearDiscardedCards: vi.fn(),
     isSpectator: false,
     createGame: vi.fn().mockResolvedValue(undefined),
     joinGame: vi.fn().mockResolvedValue(undefined),

--- a/packages/client/src/test/Lobby.test.tsx
+++ b/packages/client/src/test/Lobby.test.tsx
@@ -147,7 +147,7 @@ describe('Lobby component', () => {
       await user.click(joinButtons[0]!);
 
       await waitFor(() => {
-        expect(joinGame).toHaveBeenCalledWith('ABC123');
+        expect(joinGame).toHaveBeenCalledWith('ABC123', undefined, undefined);
       });
     });
 
@@ -179,7 +179,7 @@ describe('Lobby component', () => {
       await user.click(joinButtons[0]!);
 
       await waitFor(() => {
-        expect(joinGame).toHaveBeenCalledWith('XY99');
+        expect(joinGame).toHaveBeenCalledWith('XY99', undefined, undefined);
       });
     });
   });

--- a/packages/client/src/utils/audio.ts
+++ b/packages/client/src/utils/audio.ts
@@ -148,6 +148,37 @@ export const useAudio = () => {
     ].forEach(([freq, t]) => playTone(freq, t, 0.42, 0.14, 'sine'));
   }, [playTone]);
 
+  // Discard — bright rising swoosh + soft body thump (cards swept off the table)
+  const playDiscardSound = useCallback(() => {
+    const ctx = getCtx();
+    if (!ctx) return;
+    const comp = getCompressor(ctx);
+    const duration = 0.32;
+    const bufferSize = Math.ceil(ctx.sampleRate * duration);
+    const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < bufferSize; i++) {
+      const t = i / bufferSize;
+      const env = Math.pow(1 - t, 1.5) * Math.exp(-t * 4);
+      data[i] = (Math.random() * 2 - 1) * env;
+    }
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    const filter = ctx.createBiquadFilter();
+    filter.type = 'bandpass';
+    // Frequency sweeps from 1600 → 600 Hz for a "whoosh" feel
+    filter.frequency.setValueAtTime(1600, ctx.currentTime);
+    filter.frequency.exponentialRampToValueAtTime(600, ctx.currentTime + duration);
+    filter.Q.value = 0.8;
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.45, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
+    src.connect(filter);
+    filter.connect(gain);
+    gain.connect(comp);
+    src.start();
+  }, [getCtx, getCompressor]);
+
   return {
     playDealSound,
     playCardSound,
@@ -155,5 +186,6 @@ export const useAudio = () => {
     playTimerWarning,
     playVictorySound,
     playDefeatSound,
+    playDiscardSound,
   };
 };

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -5,12 +5,17 @@ import cors from 'cors';
 import { monitor } from '@colyseus/monitor';
 import path from 'path';
 import fs from 'fs';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
 
 import { DurakRoom } from './src/rooms/DurakRoom';
-import 'dotenv/config'; // Load environment variables from .env
+import 'dotenv/config';
 import mongoose from 'mongoose';
 import { PlayerProfile } from './src/models/PlayerProfile';
 import { GameLog } from './src/models/GameLog';
+import { User } from './src/models/User';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'durak-dev-secret-change-in-prod';
 
 if (process.env.MONGO_URI) {
   mongoose
@@ -32,7 +37,8 @@ app.use((req, res, next) => {
   next();
 });
 
-// Token exchange endpoint for Discord Embedded App SDK
+// ── Discord token exchange (Embedded App SDK) ────────────────────────────────
+
 app.post('/api/token', async (req, res) => {
   try {
     const { code } = req.body;
@@ -53,7 +59,6 @@ app.post('/api/token', async (req, res) => {
       grant_type: 'authorization_code',
       code: code,
     };
-    // Browser OAuth sends redirect_uri; embedded SDK flow does not
     if (req.body.redirect_uri) params.redirect_uri = String(req.body.redirect_uri);
 
     const response = await fetch('https://discord.com/api/oauth2/token', {
@@ -75,11 +80,110 @@ app.post('/api/token', async (req, res) => {
   }
 });
 
-// ── Profile API ─────────────────────────────────────────────────────────────
+// ── Email / password auth ────────────────────────────────────────────────────
 
-app.get('/api/profile/:discordId', async (req, res) => {
+app.post('/api/auth/register', async (req, res) => {
   try {
-    const profile = await PlayerProfile.findOne({ discordId: req.params.discordId }).lean();
+    const { email, password, username } = req.body;
+    if (!email || !password || !username) {
+      res.status(400).json({ error: 'email, password, and username are required' });
+      return;
+    }
+    if (password.length < 6) {
+      res.status(400).json({ error: 'Password must be at least 6 characters' });
+      return;
+    }
+
+    const exists = await User.findOne({ email: email.toLowerCase().trim() });
+    if (exists) {
+      res.status(409).json({ error: 'An account with that email already exists' });
+      return;
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await User.create({
+      email: email.toLowerCase().trim(),
+      passwordHash,
+      username: username.trim().slice(0, 32),
+    });
+
+    const token = jwt.sign({ userId: user._id.toString() }, JWT_SECRET, { expiresIn: '30d' });
+    res.status(201).json({
+      token,
+      user: {
+        id: user._id.toString(),
+        email: user.email,
+        username: user.username,
+        avatarUrl: user.avatarUrl,
+      },
+    });
+  } catch (e: any) {
+    console.error('Register error:', e);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post('/api/auth/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      res.status(400).json({ error: 'email and password are required' });
+      return;
+    }
+
+    const user = await User.findOne({ email: email.toLowerCase().trim() });
+    if (!user || !(await user.comparePassword(password))) {
+      res.status(401).json({ error: 'Invalid email or password' });
+      return;
+    }
+
+    const token = jwt.sign({ userId: user._id.toString() }, JWT_SECRET, { expiresIn: '30d' });
+    res.json({
+      token,
+      user: {
+        id: user._id.toString(),
+        email: user.email,
+        username: user.username,
+        avatarUrl: user.avatarUrl,
+      },
+    });
+  } catch (e: any) {
+    console.error('Login error:', e);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.get('/api/auth/me', async (req, res) => {
+  try {
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith('Bearer ')) {
+      res.status(401).json({ error: 'Missing token' });
+      return;
+    }
+    const payload = jwt.verify(auth.slice(7), JWT_SECRET) as { userId: string };
+    const user = await User.findById(payload.userId).select('-passwordHash');
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json({
+      id: user._id.toString(),
+      email: user.email,
+      username: user.username,
+      avatarUrl: user.avatarUrl,
+    });
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' });
+  }
+});
+
+// ── Profile & history API ────────────────────────────────────────────────────
+
+// Accepts ?by=discord (default) or ?by=user
+app.get('/api/profile/:id', async (req, res) => {
+  try {
+    const by = req.query.by === 'user' ? 'userId' : 'discordId';
+    const profile = await PlayerProfile.findOne({ [by]: req.params.id }).lean();
     if (!profile) {
       res.status(404).json({ error: 'Profile not found' });
       return;
@@ -90,13 +194,14 @@ app.get('/api/profile/:discordId', async (req, res) => {
   }
 });
 
-app.get('/api/history/:discordId', async (req, res) => {
+app.get('/api/history/:id', async (req, res) => {
   try {
     const limit = Math.min(parseInt(String(req.query.limit ?? '20'), 10), 100);
-    const logs = await GameLog.find({ discordIds: req.params.discordId })
+    const by = req.query.by === 'user' ? 'userIds' : 'discordIds';
+    const logs = await GameLog.find({ [by]: req.params.id })
       .sort({ date: -1 })
       .limit(limit)
-      .select('-actionLog') // exclude verbose action log from list view
+      .select('-actionLog')
       .lean();
     res.json(logs);
   } catch (e: any) {
@@ -107,14 +212,10 @@ app.get('/api/history/:discordId', async (req, res) => {
 // ────────────────────────────────────────────────────────────────────────────
 
 const server = http.createServer(app);
-const gameServer = new Server({
-  server,
-});
+const gameServer = new Server({ server });
 
-// Register the Durak game room
 gameServer.define('durak', DurakRoom).filterBy(['discordInstanceId']);
 
-// Add colyseus monitor for debugging
 app.use('/colyseus', monitor());
 
 const clientDistPath = path.resolve(__dirname, '../client/dist');

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -9,6 +9,8 @@ import fs from 'fs';
 import { DurakRoom } from './src/rooms/DurakRoom';
 import 'dotenv/config'; // Load environment variables from .env
 import mongoose from 'mongoose';
+import { PlayerProfile } from './src/models/PlayerProfile';
+import { GameLog } from './src/models/GameLog';
 
 if (process.env.MONGO_URI) {
   mongoose
@@ -70,6 +72,37 @@ app.post('/api/token', async (req, res) => {
     res.status(500).json({ error: error.message || 'Internal server error' });
   }
 });
+
+// ── Profile API ─────────────────────────────────────────────────────────────
+
+app.get('/api/profile/:discordId', async (req, res) => {
+  try {
+    const profile = await PlayerProfile.findOne({ discordId: req.params.discordId }).lean();
+    if (!profile) {
+      res.status(404).json({ error: 'Profile not found' });
+      return;
+    }
+    res.json(profile);
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.get('/api/history/:discordId', async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(String(req.query.limit ?? '20'), 10), 100);
+    const logs = await GameLog.find({ discordIds: req.params.discordId })
+      .sort({ date: -1 })
+      .limit(limit)
+      .select('-actionLog') // exclude verbose action log from list view
+      .lean();
+    res.json(logs);
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────────────
 
 const server = http.createServer(app);
 const gameServer = new Server({

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -47,17 +47,19 @@ app.post('/api/token', async (req, res) => {
       return;
     }
 
+    const params: Record<string, string> = {
+      client_id: DISCORD_CLIENT_ID,
+      client_secret: DISCORD_CLIENT_SECRET,
+      grant_type: 'authorization_code',
+      code: code,
+    };
+    // Browser OAuth sends redirect_uri; embedded SDK flow does not
+    if (req.body.redirect_uri) params.redirect_uri = String(req.body.redirect_uri);
+
     const response = await fetch('https://discord.com/api/oauth2/token', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        client_id: DISCORD_CLIENT_ID,
-        client_secret: DISCORD_CLIENT_SECRET,
-        grant_type: 'authorization_code',
-        code: code,
-      }),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(params),
     });
 
     const data = await response.json();

--- a/packages/server/src/models/GameLog.ts
+++ b/packages/server/src/models/GameLog.ts
@@ -5,6 +5,7 @@ export interface IGameLog extends mongoose.Document {
   date: Date;
   mode: string;
   players: string[];
+  discordIds: string[]; // parallel to players; empty string when no Discord account
   winners: string[];
   durak: string | null;
   huzurSetting: string;
@@ -12,10 +13,11 @@ export interface IGameLog extends mongoose.Document {
 }
 
 const GameLogSchema = new mongoose.Schema({
-  roomId: { type: String, required: true },
-  date: { type: Date, default: Date.now },
+  roomId: { type: String, required: true, index: true },
+  date: { type: Date, default: Date.now, index: true },
   mode: { type: String },
   players: [{ type: String }],
+  discordIds: [{ type: String }],
   winners: [{ type: String }],
   durak: { type: String, default: null },
   huzurSetting: { type: String },

--- a/packages/server/src/models/GameLog.ts
+++ b/packages/server/src/models/GameLog.ts
@@ -5,7 +5,8 @@ export interface IGameLog extends mongoose.Document {
   date: Date;
   mode: string;
   players: string[];
-  discordIds: string[]; // parallel to players; empty string when no Discord account
+  discordIds: string[]; // parallel to players; empty string when not a Discord account
+  userIds: string[]; // parallel to players; empty string when not an email account
   winners: string[];
   durak: string | null;
   huzurSetting: string;
@@ -18,6 +19,7 @@ const GameLogSchema = new mongoose.Schema({
   mode: { type: String },
   players: [{ type: String }],
   discordIds: [{ type: String }],
+  userIds: [{ type: String }],
   winners: [{ type: String }],
   durak: { type: String, default: null },
   huzurSetting: { type: String },

--- a/packages/server/src/models/PlayerProfile.ts
+++ b/packages/server/src/models/PlayerProfile.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 export interface IPlayerProfile extends mongoose.Document {
   discordId: string;
+  userId: string; // internal user ID for email/password accounts
   username: string;
   avatarUrl: string;
   stats: {
@@ -15,7 +16,8 @@ export interface IPlayerProfile extends mongoose.Document {
 
 const PlayerProfileSchema = new mongoose.Schema(
   {
-    discordId: { type: String, required: true, unique: true, index: true },
+    discordId: { type: String, default: '', index: true, sparse: true },
+    userId: { type: String, default: '', index: true, sparse: true },
     username: { type: String, default: '' },
     avatarUrl: { type: String, default: '' },
     stats: {

--- a/packages/server/src/models/PlayerProfile.ts
+++ b/packages/server/src/models/PlayerProfile.ts
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+export interface IPlayerProfile extends mongoose.Document {
+  discordId: string;
+  username: string;
+  avatarUrl: string;
+  stats: {
+    gamesPlayed: number;
+    wins: number;
+    losses: number;
+    durakCount: number;
+  };
+  updatedAt: Date;
+}
+
+const PlayerProfileSchema = new mongoose.Schema(
+  {
+    discordId: { type: String, required: true, unique: true, index: true },
+    username: { type: String, default: '' },
+    avatarUrl: { type: String, default: '' },
+    stats: {
+      gamesPlayed: { type: Number, default: 0 },
+      wins: { type: Number, default: 0 },
+      losses: { type: Number, default: 0 },
+      durakCount: { type: Number, default: 0 },
+    },
+  },
+  { timestamps: true },
+);
+
+export const PlayerProfile = mongoose.model<IPlayerProfile>('PlayerProfile', PlayerProfileSchema);

--- a/packages/server/src/models/User.ts
+++ b/packages/server/src/models/User.ts
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+import bcrypt from 'bcryptjs';
+
+export interface IUser extends mongoose.Document {
+  email: string;
+  passwordHash: string;
+  username: string;
+  avatarUrl: string;
+  comparePassword: (password: string) => Promise<boolean>;
+}
+
+const UserSchema = new mongoose.Schema(
+  {
+    email: { type: String, required: true, unique: true, lowercase: true, trim: true, index: true },
+    passwordHash: { type: String, required: true },
+    username: { type: String, required: true, trim: true },
+    avatarUrl: { type: String, default: '' },
+  },
+  { timestamps: true },
+);
+
+UserSchema.methods.comparePassword = function (password: string): Promise<boolean> {
+  return bcrypt.compare(password, this.passwordHash);
+};
+
+export const User = mongoose.model<IUser>('User', UserSchema);

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -282,6 +282,7 @@ export class DurakRoom extends Room<GameState> {
       player.avatarUrl = String(options.avatarUrl).trim().slice(0, MAX_AVATAR_URL_LEN);
     if (options.discordId)
       player.discordId = String(options.discordId).trim().slice(0, MAX_SHORT_STRING_LEN);
+    if (options.userId) player.userId = String(options.userId).trim().slice(0, 64);
 
     // First player is host
     if (this.state.players.size === 0) {
@@ -1020,6 +1021,7 @@ export class DurakRoom extends Room<GameState> {
       const sessionIds = Array.from(this.state.players.keys());
       const players = sessionIds.map((id) => this.state.players.get(id)!);
       const discordIds = players.map((p) => p?.discordId ?? '');
+      const userIds = players.map((p) => p?.userId ?? '');
       const winnerSessions = Array.from(this.state.winners);
 
       const log = new GameLog({
@@ -1027,6 +1029,7 @@ export class DurakRoom extends Room<GameState> {
         mode: this.state.mode,
         players: sessionIds,
         discordIds,
+        userIds,
         winners: winnerSessions,
         durak: this.state.loser,
         huzurSetting: this.state.huzurSuit,
@@ -1035,16 +1038,20 @@ export class DurakRoom extends Room<GameState> {
       await log.save();
       console.log(`Saved GameLog to MongoDB for room ${this.roomId}`);
 
-      // Upsert a PlayerProfile for every Discord-authenticated participant
+      // Upsert PlayerProfile for every authenticated participant (Discord or email)
       const profileOps = players
-        .filter((p) => p?.discordId)
+        .filter((p) => p?.discordId || p?.userId)
         .map((p) => {
           const isWinner = winnerSessions.includes(p.id);
           const isDurak = this.state.loser === p.id;
+          const filter = p.discordId ? { discordId: p.discordId } : { userId: p.userId };
+          const setFields = p.discordId
+            ? { discordId: p.discordId, username: p.username, avatarUrl: p.avatarUrl }
+            : { userId: p.userId, username: p.username, avatarUrl: p.avatarUrl };
           return PlayerProfile.findOneAndUpdate(
-            { discordId: p.discordId },
+            filter,
             {
-              $set: { username: p.username, avatarUrl: p.avatarUrl },
+              $set: setFields,
               $inc: {
                 'stats.gamesPlayed': 1,
                 'stats.wins': isWinner ? 1 : 0,

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -2,6 +2,7 @@ import { Room, Client } from 'colyseus';
 import { GameState, DurakEngine, Card, Player } from '@durak/shared';
 
 import { GameLog } from '../models/GameLog';
+import { PlayerProfile } from '../models/PlayerProfile';
 import mongoose from 'mongoose';
 import { openAIBot, BotDifficulty } from '../ai/OpenAIBot';
 
@@ -279,6 +280,8 @@ export class DurakRoom extends Room<GameState> {
       player.username = String(options.username).trim().slice(0, MAX_USERNAME_LEN);
     if (options.avatarUrl)
       player.avatarUrl = String(options.avatarUrl).trim().slice(0, MAX_AVATAR_URL_LEN);
+    if (options.discordId)
+      player.discordId = String(options.discordId).trim().slice(0, MAX_SHORT_STRING_LEN);
 
     // First player is host
     if (this.state.players.size === 0) {
@@ -1012,20 +1015,47 @@ export class DurakRoom extends Room<GameState> {
 
   private async saveGameLog() {
     try {
-      // Only attempt to save if mongoose has an active connection (i.e. MONGO_URI is set)
-      if (mongoose.connection.readyState === 1 || mongoose.connection.readyState === 2) {
-        const log = new GameLog({
-          roomId: this.roomId,
-          mode: this.state.mode,
-          players: Array.from(this.state.players.keys()),
-          winners: Array.from(this.state.winners),
-          durak: this.state.loser,
-          huzurSetting: this.state.huzurSuit,
-          actionLog: Array.from(this.state.actionLog),
+      if (mongoose.connection.readyState !== 1 && mongoose.connection.readyState !== 2) return;
+
+      const sessionIds = Array.from(this.state.players.keys());
+      const players = sessionIds.map((id) => this.state.players.get(id)!);
+      const discordIds = players.map((p) => p?.discordId ?? '');
+      const winnerSessions = Array.from(this.state.winners);
+
+      const log = new GameLog({
+        roomId: this.roomId,
+        mode: this.state.mode,
+        players: sessionIds,
+        discordIds,
+        winners: winnerSessions,
+        durak: this.state.loser,
+        huzurSetting: this.state.huzurSuit,
+        actionLog: Array.from(this.state.actionLog),
+      });
+      await log.save();
+      console.log(`Saved GameLog to MongoDB for room ${this.roomId}`);
+
+      // Upsert a PlayerProfile for every Discord-authenticated participant
+      const profileOps = players
+        .filter((p) => p?.discordId)
+        .map((p) => {
+          const isWinner = winnerSessions.includes(p.id);
+          const isDurak = this.state.loser === p.id;
+          return PlayerProfile.findOneAndUpdate(
+            { discordId: p.discordId },
+            {
+              $set: { username: p.username, avatarUrl: p.avatarUrl },
+              $inc: {
+                'stats.gamesPlayed': 1,
+                'stats.wins': isWinner ? 1 : 0,
+                'stats.losses': isDurak ? 1 : 0,
+                'stats.durakCount': isDurak ? 1 : 0,
+              },
+            },
+            { upsert: true, new: true },
+          );
         });
-        await log.save();
-        console.log(`Saved GameLog to MongoDB for room ${this.roomId}`);
-      }
+      await Promise.all(profileOps);
     } catch (e) {
       console.error('Failed to save GameLog to MongoDB:', e);
     }

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -88,16 +88,17 @@ export class DurakRoom extends Room<GameState> {
       if (client.sessionId !== this.state.hostId) return;
 
       if (message.action === 'spawn_dummies') {
-        const currentPlayers = this.state.players.size;
-        const count = message.count || this.state.maxPlayers - currentPlayers;
+        const count = message.count || this.state.maxPlayers - this.state.players.size;
+        const isDummy = message.difficulty === 'dummy';
         const difficulty: BotDifficulty = message.difficulty === 'hard' ? 'hard' : 'easy';
 
         let spawned = 0;
         for (let i = 0; i < count; i++) {
           if (this.state.players.size >= this.state.maxPlayers) break;
-          const id = `bot-${Math.random().toString(36).substring(2, 7)}`;
+          const prefix = isDummy ? 'dummy' : 'bot';
+          const id = `${prefix}-${Math.random().toString(36).substring(2, 7)}`;
           const p = new Player(id);
-          p.username = `Bot (${difficulty})`;
+          p.username = isDummy ? `Dummy` : `Bot (${difficulty})`;
           p.isReady = true;
 
           if (this.state.mode === 'teams') {
@@ -111,12 +112,14 @@ export class DurakRoom extends Room<GameState> {
           }
 
           this.state.players.set(id, p);
-          this.botIds.set(id, difficulty);
+          // Dummies have no AI — they are controlled manually via play_as dev actions
+          if (!isDummy) this.botIds.set(id, difficulty);
           spawned++;
         }
+        const label = isDummy ? 'dummy/dummies' : `${difficulty} bot(s)`;
         this.broadcast(
           'info',
-          `Spawned ${spawned} ${difficulty} bot(s). Room is at ${this.state.players.size}/${this.state.maxPlayers}`,
+          `Spawned ${spawned} ${label}. Room is at ${this.state.players.size}/${this.state.maxPlayers}`,
         );
       }
 
@@ -632,14 +635,17 @@ export class DurakRoom extends Room<GameState> {
   private nextTurn() {
     const ids = Array.from(this.state.seatOrder);
     const idx = ids.indexOf(this.state.currentTurn);
-    if (idx !== -1) {
-      const nextId = ids[(idx + 1) % ids.length];
-      if (nextId) {
-        this.state.currentTurn = nextId;
-        this.state.turnStartTime = Date.now();
-        this.startTurnTimer();
-        this.scheduleBotTurn(nextId);
-      }
+    if (idx === -1) return;
+
+    // Skip players who have already won — they have no cards and can't act
+    for (let skip = 1; skip < ids.length; skip++) {
+      const candidateId = ids[(idx + skip) % ids.length];
+      if (!candidateId || this.state.winners.includes(candidateId)) continue;
+      this.state.currentTurn = candidateId;
+      this.state.turnStartTime = Date.now();
+      this.startTurnTimer();
+      this.scheduleBotTurn(candidateId);
+      return;
     }
   }
 
@@ -891,7 +897,17 @@ export class DurakRoom extends Room<GameState> {
     // Increment chain
     this.state.defenseChainCount++;
 
-    if (this.state.defenseChainCount >= this.state.players.size - 1) {
+    const activePlayers = Array.from(this.state.seatOrder).filter(
+      (id): id is string => !!id && !this.state.winners.includes(id),
+    ).length;
+    if (this.state.defenseChainCount >= activePlayers - 1) {
+      // Broadcast the cards before clearing so clients can animate the discard
+      const discardedCards = [
+        ...Array.from(this.state.tableStacks).filter((c): c is Card => !!c),
+        ...Array.from(this.state.activeAttackCards).filter((c): c is Card => !!c),
+      ].map((c) => ({ suit: c.suit, rank: c.rank, isJoker: c.isJoker }));
+      this.broadcast('roundDiscarded', { cards: discardedCards });
+
       // Everyone in the circle successfully defended!
       DurakEngine.endRound(this.state, null);
 

--- a/packages/shared/src/state/Player.ts
+++ b/packages/shared/src/state/Player.ts
@@ -6,6 +6,7 @@ export class Player extends Schema {
   @type('string') username: string = '';
   @type('string') avatarUrl: string = '';
   @type('string') discordId: string = '';
+  @type('string') userId: string = ''; // internal ID for email/password accounts
   @type([Card]) hand = new ArraySchema<Card>();
   @type(['string']) pickedUpCardKeys = new ArraySchema<string>();
   @type('boolean') hasPickedUp: boolean = false;

--- a/packages/shared/src/state/Player.ts
+++ b/packages/shared/src/state/Player.ts
@@ -5,6 +5,7 @@ export class Player extends Schema {
   @type('string') id: string = '';
   @type('string') username: string = '';
   @type('string') avatarUrl: string = '';
+  @type('string') discordId: string = '';
   @type([Card]) hand = new ArraySchema<Card>();
   @type(['string']) pickedUpCardKeys = new ArraySchema<string>();
   @type('boolean') hasPickedUp: boolean = false;


### PR DESCRIPTION
## Summary

### Auth & Player Profiles (new)
- **Persistent player profiles** — stats (games played, wins, losses, durak count) are upserted in MongoDB at game end for both Discord and email-account players. REST endpoints: `GET /api/profile/:id` and `GET /api/history/:id` (closes #145, #147).
- **Discord OAuth login** — browser lobby has a login panel with \"Continue with Discord\" OAuth2 flow. Identity is resolved: embedded Activity SDK > browser Discord OAuth > email account.
- **Email / password auth** — register/login with email+password alongside Discord. JWTs issued with 30-day expiry. `POST /api/auth/register`, `POST /api/auth/login`, `GET /api/auth/me`.
- **Player profile panel** — stats + last 10 matches shown in the lobby sidebar when logged in.
- **Env fix** — `envDir` pinned in `vite.config.ts` so `VITE_DISCORD_CLIENT_ID` is picked up correctly when Vite is invoked through npm workspaces.

### Gameplay
- **Discard animation & sound** — after all defenses succeed, a `roundDiscarded` event broadcasts played cards. A horizontal card-spread overlay appears with a bandpass whoosh sound (1600→600 Hz sweep), auto-clears after 2.5 s.
- **Pair-aware attack/defense stack** — `tableStacks` rendered as matched atk/def pairs so each defense card visually overlays its matching attack card (green ring). Dedup guard prevents chain-link cards appearing twice.
- **Bot game-over fix** — `nextTurn()` skips players in the `winners` array, so a bot that empties its hand is no longer assigned turns (game freeze fix).
- **Dummy spawning (dev mode)** — dev panel gains a \"Spawn Dummy\" button per slot. Dummies join seat order but receive no bot AI moves — useful for testing specific board states.

## New models / API

| Endpoint | Description |
|----------|-------------|
| `POST /api/auth/register` | Email+password registration, returns JWT |
| `POST /api/auth/login` | Email+password login, returns JWT |
| `GET /api/auth/me` | Verify Bearer token, return user |
| `GET /api/profile/:id?by=user\|discord` | Player profile + stats |
| `GET /api/history/:id?by=user\|discord&limit=N` | Last N match records |

## Test plan

- [ ] Click \"Continue with Discord\" in lobby → redirected to Discord → returns and shows profile panel
- [ ] Register with email+password → profile panel appears with username
- [ ] Log in with email+password → stats load from previous games
- [ ] Play a game to completion → stats increment for both Discord and email users
- [ ] Let a bot win mid-game → game continues for remaining players (no freeze)
- [ ] Successful defense round → discard spread animation plays with sound
- [ ] Dev mode: spawn a dummy → sits in seat, receives no bot moves
- [ ] `npm test` — all tests pass
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)