### PR TITLE
feat(#146): ELO rating system

### DIFF
--- a/packages/client/src/components/PlayerProfilePanel.tsx
+++ b/packages/client/src/components/PlayerProfilePanel.tsx
@@ -12,6 +12,8 @@ interface Profile {
   username: string;
   avatarUrl: string;
   stats: ProfileStats;
+  eloClassic: number;
+  eloTeams: number;
   updatedAt: string;
 }
 
@@ -23,6 +25,15 @@ interface MatchRecord {
   discordIds: string[];
   winners: string[];
   durak: string | null;
+}
+
+interface LeaderEntry {
+  _id: string;
+  username: string;
+  avatarUrl: string;
+  eloClassic: number;
+  eloTeams: number;
+  stats: { gamesPlayed: number };
 }
 
 interface Props {
@@ -37,8 +48,10 @@ const API = '/api';
 export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarUrl, username }) => {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [history, setHistory] = useState<MatchRecord[]>([]);
+  const [leaders, setLeaders] = useState<LeaderEntry[]>([]);
   const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState<'stats' | 'history'>('stats');
+  const [tab, setTab] = useState<'stats' | 'history' | 'leaderboard'>('stats');
+  const [leaderMode, setLeaderMode] = useState<'classic' | 'teams'>('classic');
 
   const id = discordId ?? userId ?? '';
   const byParam = userId && !discordId ? '&by=user' : '';
@@ -70,9 +83,26 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarU
     };
   }, [discordId]);
 
+  useEffect(() => {
+    if (tab !== 'leaderboard') return;
+    let cancelled = false;
+    fetch(`${API}/leaderboard?mode=${leaderMode}&limit=10`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        if (!cancelled) setLeaders(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        if (!cancelled) setLeaders([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, leaderMode]);
+
   const stats = profile?.stats;
   const winRate =
     stats && stats.gamesPlayed > 0 ? Math.round((stats.wins / stats.gamesPlayed) * 100) : 0;
+  const elo = profile?.eloClassic ?? 1000;
 
   return (
     <div className="bg-indigo-950 border border-indigo-700 rounded-xl p-5 text-white">
@@ -91,13 +121,17 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarU
         )}
         <div>
           <div className="font-bold text-lg leading-tight">{username}</div>
-          <div className="text-indigo-400 text-xs">Discord Player</div>
+          {profile && (
+            <div className="text-yellow-400 text-xs font-semibold">
+              ★ {elo} <span className="text-indigo-400 font-normal">ELO</span>
+            </div>
+          )}
         </div>
       </div>
 
       {/* Tabs */}
       <div className="flex gap-2 mb-4">
-        {(['stats', 'history'] as const).map((t) => (
+        {(['stats', 'history', 'leaderboard'] as const).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
@@ -107,12 +141,12 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarU
                 : 'bg-indigo-900 text-indigo-300 hover:bg-indigo-800'
             }`}
           >
-            {t}
+            {t === 'leaderboard' ? '🏆' : t}
           </button>
         ))}
       </div>
 
-      {loading ? (
+      {loading && tab !== 'leaderboard' ? (
         <div className="text-indigo-400 text-sm text-center py-4 animate-pulse">Loading...</div>
       ) : tab === 'stats' ? (
         stats ? (
@@ -121,14 +155,35 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarU
             <StatCard label="Win Rate" value={`${winRate}%`} highlight={winRate >= 50} />
             <StatCard label="Wins" value={stats.wins} highlight />
             <StatCard label="Durak" value={stats.durakCount} dim />
+            <div className="col-span-2 bg-indigo-900/60 rounded-lg p-3 flex justify-between items-center">
+              <div>
+                <div className="text-yellow-400 font-bold text-xl">
+                  ★ {profile?.eloClassic ?? 1000}
+                </div>
+                <div className="text-indigo-400 text-xs mt-0.5">Classic ELO</div>
+              </div>
+              <div className="text-right">
+                <div className="text-yellow-400 font-bold text-xl">
+                  ★ {profile?.eloTeams ?? 1000}
+                </div>
+                <div className="text-indigo-400 text-xs mt-0.5">Teams ELO</div>
+              </div>
+            </div>
           </div>
         ) : (
           <div className="text-indigo-400 text-sm text-center py-4">
             No stats yet — play a game to get started.
           </div>
         )
-      ) : (
+      ) : tab === 'history' ? (
         <HistoryList history={history} playerId={id} />
+      ) : (
+        <LeaderboardList
+          leaders={leaders}
+          mode={leaderMode}
+          onModeChange={setLeaderMode}
+          myId={id}
+        />
       )}
     </div>
   );
@@ -186,3 +241,50 @@ const HistoryList: React.FC<{ history: MatchRecord[]; playerId: string }> = ({
     </div>
   );
 };
+
+const LeaderboardList: React.FC<{
+  leaders: LeaderEntry[];
+  mode: 'classic' | 'teams';
+  onModeChange: (m: 'classic' | 'teams') => void;
+  myId: string;
+}> = ({ leaders, mode, onModeChange, myId }) => (
+  <div>
+    <div className="flex gap-2 mb-3">
+      {(['classic', 'teams'] as const).map((m) => (
+        <button
+          key={m}
+          onClick={() => onModeChange(m)}
+          className={`px-3 py-1 rounded text-xs font-semibold capitalize transition ${
+            mode === m
+              ? 'bg-yellow-600 text-white'
+              : 'bg-indigo-900 text-indigo-300 hover:bg-indigo-800'
+          }`}
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+    {leaders.length === 0 ? (
+      <div className="text-indigo-400 text-sm text-center py-4">No ranked players yet.</div>
+    ) : (
+      <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
+        {leaders.map((p, i) => {
+          const elo = mode === 'classic' ? p.eloClassic : p.eloTeams;
+          const isMe = p._id === myId || p.username === myId;
+          return (
+            <div
+              key={p._id}
+              className={`flex items-center gap-2 px-3 py-2 rounded text-xs ${
+                isMe ? 'bg-yellow-900/40 border border-yellow-700' : 'bg-indigo-900/50'
+              }`}
+            >
+              <span className="text-indigo-500 w-4 text-right shrink-0">{i + 1}</span>
+              <span className="flex-1 font-semibold truncate">{p.username}</span>
+              <span className="text-yellow-400 font-bold">★ {elo}</span>
+            </div>
+          );
+        })}
+      </div>
+    )}
+  </div>
+);

--- a/packages/client/src/components/PlayerProfilePanel.tsx
+++ b/packages/client/src/components/PlayerProfilePanel.tsx
@@ -8,6 +8,7 @@ interface ProfileStats {
 }
 
 interface Profile {
+  _id: string;
   discordId: string;
   username: string;
   avatarUrl: string;
@@ -182,7 +183,7 @@ export const PlayerProfilePanel: React.FC<Props> = ({ discordId, userId, avatarU
           leaders={leaders}
           mode={leaderMode}
           onModeChange={setLeaderMode}
-          myId={id}
+          myProfileId={profile?._id}
         />
       )}
     </div>
@@ -246,8 +247,8 @@ const LeaderboardList: React.FC<{
   leaders: LeaderEntry[];
   mode: 'classic' | 'teams';
   onModeChange: (m: 'classic' | 'teams') => void;
-  myId: string;
-}> = ({ leaders, mode, onModeChange, myId }) => (
+  myProfileId?: string;
+}> = ({ leaders, mode, onModeChange, myProfileId }) => (
   <div>
     <div className="flex gap-2 mb-3">
       {(['classic', 'teams'] as const).map((m) => (
@@ -270,7 +271,7 @@ const LeaderboardList: React.FC<{
       <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
         {leaders.map((p, i) => {
           const elo = mode === 'classic' ? p.eloClassic : p.eloTeams;
-          const isMe = p._id === myId || p.username === myId;
+          const isMe = !!myProfileId && p._id === myProfileId;
           return (
             <div
               key={p._id}

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -194,6 +194,21 @@ app.get('/api/profile/:id', async (req, res) => {
   }
 });
 
+app.get('/api/leaderboard', async (req, res) => {
+  try {
+    const mode = req.query.mode === 'teams' ? 'eloTeams' : 'eloClassic';
+    const limit = Math.min(parseInt(String(req.query.limit ?? '10'), 10), 50);
+    const leaders = await PlayerProfile.find({ 'stats.gamesPlayed': { $gte: 1 } })
+      .sort({ [mode]: -1 })
+      .limit(limit)
+      .select('username avatarUrl eloClassic eloTeams stats.gamesPlayed')
+      .lean();
+    res.json(leaders);
+  } catch (e: unknown) {
+    res.status(500).json({ error: e instanceof Error ? e.message : 'Server error' });
+  }
+});
+
 app.get('/api/history/:id', async (req, res) => {
   try {
     const limit = Math.min(parseInt(String(req.query.limit ?? '20'), 10), 100);

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -197,7 +197,8 @@ app.get('/api/profile/:id', async (req, res) => {
 app.get('/api/leaderboard', async (req, res) => {
   try {
     const mode = req.query.mode === 'teams' ? 'eloTeams' : 'eloClassic';
-    const limit = Math.min(parseInt(String(req.query.limit ?? '10'), 10), 50);
+    const rawLimit = parseInt(String(req.query.limit ?? '10'), 10);
+    const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 50)) : 10;
     const leaders = await PlayerProfile.find({ 'stats.gamesPlayed': { $gte: 1 } })
       .sort({ [mode]: -1 })
       .limit(limit)

--- a/packages/server/src/models/PlayerProfile.ts
+++ b/packages/server/src/models/PlayerProfile.ts
@@ -11,6 +11,8 @@ export interface IPlayerProfile extends mongoose.Document {
     losses: number;
     durakCount: number;
   };
+  eloClassic: number;
+  eloTeams: number;
   updatedAt: Date;
 }
 
@@ -26,6 +28,8 @@ const PlayerProfileSchema = new mongoose.Schema(
       losses: { type: Number, default: 0 },
       durakCount: { type: Number, default: 0 },
     },
+    eloClassic: { type: Number, default: 1000 },
+    eloTeams: { type: Number, default: 1000 },
   },
   { timestamps: true },
 );

--- a/packages/server/src/models/PlayerProfile.ts
+++ b/packages/server/src/models/PlayerProfile.ts
@@ -34,4 +34,8 @@ const PlayerProfileSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
+// Compound indexes to cover leaderboard query: filter by gamesPlayed, sort by elo
+PlayerProfileSchema.index({ 'stats.gamesPlayed': 1, eloClassic: -1 });
+PlayerProfileSchema.index({ 'stats.gamesPlayed': 1, eloTeams: -1 });
+
 export const PlayerProfile = mongoose.model<IPlayerProfile>('PlayerProfile', PlayerProfileSchema);

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -3,6 +3,7 @@ import { GameState, DurakEngine, Card, Player } from '@durak/shared';
 
 import { GameLog } from '../models/GameLog';
 import { PlayerProfile } from '../models/PlayerProfile';
+import { calculateEloDeltas, EloPlayer } from '../utils/EloEngine';
 import mongoose from 'mongoose';
 import { openAIBot, BotDifficulty } from '../ai/OpenAIBot';
 
@@ -1039,29 +1040,55 @@ export class DurakRoom extends Room<GameState> {
       console.log(`Saved GameLog to MongoDB for room ${this.roomId}`);
 
       // Upsert PlayerProfile for every authenticated participant (Discord or email)
-      const profileOps = players
-        .filter((p) => p?.discordId || p?.userId)
-        .map((p) => {
-          const isWinner = winnerSessions.includes(p.id);
-          const isDurak = this.state.loser === p.id;
+      const authedPlayers = players.filter((p) => p?.discordId || p?.userId);
+      const eloField = this.state.mode === 'teams' ? 'eloTeams' : 'eloClassic';
+
+      // Fetch current profiles so we can compute Elo deltas
+      const currentProfiles = await Promise.all(
+        authedPlayers.map((p) => {
           const filter = p.discordId ? { discordId: p.discordId } : { userId: p.userId };
-          const setFields = p.discordId
-            ? { discordId: p.discordId, username: p.username, avatarUrl: p.avatarUrl }
-            : { userId: p.userId, username: p.username, avatarUrl: p.avatarUrl };
-          return PlayerProfile.findOneAndUpdate(
-            filter,
-            {
-              $set: setFields,
-              $inc: {
-                'stats.gamesPlayed': 1,
-                'stats.wins': isWinner ? 1 : 0,
-                'stats.losses': isDurak ? 1 : 0,
-                'stats.durakCount': isDurak ? 1 : 0,
-              },
+          return PlayerProfile.findOne(filter);
+        }),
+      );
+
+      const eloInputs: EloPlayer[] = authedPlayers.map((p, i) => {
+        const prof = currentProfiles[i];
+        const isWinner = winnerSessions.includes(p.id);
+        const isDurak = this.state.loser === p.id;
+        return {
+          id: p.id,
+          currentElo: prof?.[eloField] ?? 1000,
+          gamesPlayed: prof?.stats.gamesPlayed ?? 0,
+          placement: isWinner ? 'winner' : isDurak ? 'durak' : 'middle',
+        };
+      });
+
+      const eloDeltas = calculateEloDeltas(eloInputs);
+
+      const profileOps = authedPlayers.map((p, i) => {
+        const isWinner = winnerSessions.includes(p.id);
+        const isDurak = this.state.loser === p.id;
+        const delta = eloDeltas.get(p.id) ?? 0;
+        const currentElo = eloInputs[i].currentElo;
+        const newElo = Math.max(100, currentElo + delta);
+        const filter = p.discordId ? { discordId: p.discordId } : { userId: p.userId };
+        const setFields = p.discordId
+          ? { discordId: p.discordId, username: p.username, avatarUrl: p.avatarUrl }
+          : { userId: p.userId, username: p.username, avatarUrl: p.avatarUrl };
+        return PlayerProfile.findOneAndUpdate(
+          filter,
+          {
+            $set: { ...setFields, [eloField]: newElo },
+            $inc: {
+              'stats.gamesPlayed': 1,
+              'stats.wins': isWinner ? 1 : 0,
+              'stats.losses': isDurak ? 1 : 0,
+              'stats.durakCount': isDurak ? 1 : 0,
             },
-            { upsert: true, new: true },
-          );
-        });
+          },
+          { upsert: true, new: true },
+        );
+      });
       await Promise.all(profileOps);
     } catch (e) {
       console.error('Failed to save GameLog to MongoDB:', e);

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -1065,27 +1065,31 @@ export class DurakRoom extends Room<GameState> {
 
       const eloDeltas = calculateEloDeltas(eloInputs);
 
-      const profileOps = authedPlayers.map((p, i) => {
+      const profileOps = authedPlayers.map((p) => {
         const isWinner = winnerSessions.includes(p.id);
         const isDurak = this.state.loser === p.id;
         const delta = eloDeltas.get(p.id) ?? 0;
-        const currentElo = eloInputs[i].currentElo;
-        const newElo = Math.max(100, currentElo + delta);
         const filter = p.discordId ? { discordId: p.discordId } : { userId: p.userId };
         const setFields = p.discordId
           ? { discordId: p.discordId, username: p.username, avatarUrl: p.avatarUrl }
           : { userId: p.userId, username: p.username, avatarUrl: p.avatarUrl };
+        // Aggregation pipeline update so Elo is computed atomically in the DB:
+        // max(100, storedElo + delta) prevents JS read-modify-write races when
+        // a player finishes two concurrent games in different rooms.
         return PlayerProfile.findOneAndUpdate(
           filter,
-          {
-            $set: { ...setFields, [eloField]: newElo },
-            $inc: {
-              'stats.gamesPlayed': 1,
-              'stats.wins': isWinner ? 1 : 0,
-              'stats.losses': isDurak ? 1 : 0,
-              'stats.durakCount': isDurak ? 1 : 0,
+          [
+            {
+              $set: {
+                ...setFields,
+                [eloField]: { $max: [100, { $add: [`$${eloField}`, delta] }] },
+                'stats.gamesPlayed': { $add: ['$stats.gamesPlayed', 1] },
+                'stats.wins': { $add: ['$stats.wins', isWinner ? 1 : 0] },
+                'stats.losses': { $add: ['$stats.losses', isDurak ? 1 : 0] },
+                'stats.durakCount': { $add: ['$stats.durakCount', isDurak ? 1 : 0] },
+              },
             },
-          },
+          ],
           { upsert: true, new: true },
         );
       });

--- a/packages/server/src/utils/EloEngine.ts
+++ b/packages/server/src/utils/EloEngine.ts
@@ -1,0 +1,59 @@
+// Standard Elo with pairwise comparison for multi-player games.
+// Each pair (winner vs loser, winner vs middle, middle vs durak) is evaluated
+// independently and contributions are averaged over (N-1) opponents so that
+// total Elo movement stays proportional regardless of player count.
+
+export type Placement = 'winner' | 'middle' | 'durak';
+
+export interface EloPlayer {
+  id: string;
+  currentElo: number;
+  gamesPlayed: number; // used to select K-factor
+  placement: Placement;
+}
+
+function kFactor(gamesPlayed: number): number {
+  if (gamesPlayed < 20) return 40;
+  if (gamesPlayed < 50) return 24;
+  return 16;
+}
+
+function expected(ratingA: number, ratingB: number): number {
+  return 1 / (1 + Math.pow(10, (ratingB - ratingA) / 400));
+}
+
+function placementScore(p: Placement): number {
+  if (p === 'winner') return 1;
+  if (p === 'durak') return 0;
+  return 0.5;
+}
+
+/** Returns a map of player id → Elo delta (rounded to integer). */
+export function calculateEloDeltas(players: EloPlayer[]): Map<string, number> {
+  const deltas = new Map<string, number>(players.map((p) => [p.id, 0]));
+  const n = players.length;
+  if (n < 2) return deltas;
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const a = players[i];
+      const b = players[j];
+
+      // Draws between two middle-placed players — no Elo movement.
+      if (a.placement === 'middle' && b.placement === 'middle') continue;
+
+      const sA = placementScore(a.placement);
+      const sB = placementScore(b.placement);
+      const eA = expected(a.currentElo, b.currentElo);
+      const eB = expected(b.currentElo, a.currentElo);
+
+      // Divide by (n-1) so total swing ≈ one full K regardless of player count.
+      deltas.set(a.id, deltas.get(a.id)! + (kFactor(a.gamesPlayed) * (sA - eA)) / (n - 1));
+      deltas.set(b.id, deltas.get(b.id)! + (kFactor(b.gamesPlayed) * (sB - eB)) / (n - 1));
+    }
+  }
+
+  // Round to integers
+  deltas.forEach((v, k) => deltas.set(k, Math.round(v)));
+  return deltas;
+}


### PR DESCRIPTION
## Summary

- **EloEngine** (`packages/server/src/utils/EloEngine.ts`) — pairwise comparison for multi-player games. Each pair (winner vs durak, winner vs middle, middle vs durak) is evaluated with standard Elo math; middle vs middle pairs are treated as draws. K-factor: 40 for <20 games, 24 for <50, 16 for experienced players. Total delta is divided by (N-1) so Elo movement stays proportional regardless of player count. Floor of 100.
- **PlayerProfile** — added `eloClassic` and `eloTeams` fields (default 1000). Classic and teams ratings are tracked separately.
- **saveGameLog** — fetches current profiles, computes deltas via EloEngine, writes new Elo with `$set` alongside existing `$inc` stats.
- **`GET /api/leaderboard?mode=classic|teams&limit=N`** — returns top players sorted by Elo.
- **PlayerProfilePanel** — Elo shown in the header (★ 1234 ELO), Classic/Teams ELO cards in the stats grid, and a new leaderboard tab (🏆) with classic/teams toggle.

## Test plan

- [ ] Play a 2-player game to completion — both players' Elo updates (winner gains, durak loses)
- [ ] Play a 6-player game — winner gains, durak loses, middle players near-neutral
- [ ] Profile panel shows correct Elo after game
- [ ] Leaderboard tab lists players sorted by Elo
- [ ] Teams game updates `eloTeams`, classic updates `eloClassic`
- [ ] `npm test` passes

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a leaderboard tab to player profiles with a trophy icon, showing top players and highlighting the current user.
  * Classic and Teams ELO modes with a toggle; leaderboard limits and empty-state handling included.
  * Player profiles now display Classic and Teams ELO.
  * ELO ratings update after matches so leaderboard and profiles reflect recent results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/184)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->