### PR TITLE
feat(#141): Redis presence and driver for horizontal scaling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - .env
     environment:
       - PORT=2567
-      - REDIS_URI=redis://redis:6379
+      - REDIS_URL=redis://redis:6379
     depends_on:
       - redis
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -9037,6 +9037,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@colyseus/monitor": "^0.15.0",
+        "@colyseus/redis-driver": "^0.15.0",
+        "@colyseus/redis-presence": "^0.15.0",
         "@durak/shared": "*",
         "colyseus": "^0.15.0",
         "cors": "^2.8.5",

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,4 +1,6 @@
 import { Server } from 'colyseus';
+import { RedisPresence } from '@colyseus/redis-presence';
+import { RedisDriver } from '@colyseus/redis-driver';
 import express from 'express';
 import http from 'http';
 import cors from 'cors';
@@ -228,7 +230,17 @@ app.get('/api/history/:id', async (req, res) => {
 // ────────────────────────────────────────────────────────────────────────────
 
 const server = http.createServer(app);
-const gameServer = new Server({ server });
+
+const redisUrl = process.env.REDIS_URL;
+const gameServer = new Server({
+  server,
+  ...(redisUrl
+    ? {
+        presence: new RedisPresence(redisUrl),
+        driver: new RedisDriver(redisUrl),
+      }
+    : {}),
+});
 
 gameServer.define('durak', DurakRoom).filterBy(['discordInstanceId']);
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@colyseus/monitor": "^0.15.0",
+    "@colyseus/redis-driver": "^0.15.0",
+    "@colyseus/redis-presence": "^0.15.0",
     "@durak/shared": "*",
     "colyseus": "^0.15.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Wires up `RedisPresence` and `RedisDriver` (both already bundled inside `colyseus@0.15`) so multiple server instances can coordinate rooms, subscriptions, and matchmaking through a shared Redis instance.

- When `REDIS_URL` is set, `RedisPresence` and `RedisDriver` are passed to the Colyseus `Server` constructor — rooms created on any instance are visible to all instances.
- When `REDIS_URL` is absent (local dev without Docker), the server falls back to the default in-memory presence/driver with no code change needed.
- Fixed `docker-compose.yml`: `REDIS_URI` → `REDIS_URL` to match the env var the server now reads.

## Deploy checklist

- [ ] Set `REDIS_URL=redis://<host>:6379` in the production environment (Fly.io secret, Railway variable, etc.)
- [ ] Redis service must be reachable from all server instances on that URL
- [ ] `docker compose up --build` works locally with Redis container

## Test plan

- [ ] `docker compose up --build` — server starts, logs show it's listening
- [ ] Connect two clients, create a room — matchmaking works normally
- [ ] `npm test` passes (tests use in-memory driver, no Redis needed)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Redis environment variable naming in deployment configuration for consistency.
* **New Features**
  * Server now optionally enables Redis-backed presence and driver when configured, falling back to in-memory behavior otherwise; required runtime packages were added to support this.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/185)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->