### PR TITLE
fix(#150): harden JWT_SECRET in production and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# ── Server ───────────────────────────────────────────────────────────────────
+
+# MongoDB connection string (required in production)
+MONGO_URI=mongodb+srv://user:password@cluster.mongodb.net/durak
+
+# JWT secret for email/password auth tokens — MUST be set in production.
+# Generate with: openssl rand -hex 32
+JWT_SECRET=change-me-in-production
+
+# Redis connection URL (optional — enables multi-instance horizontal scaling)
+REDIS_URL=redis://localhost:6379
+
+# Port the Colyseus server listens on (default: 2567)
+PORT=2567
+
+# ── Discord OAuth (server-side token exchange) ────────────────────────────────
+
+DISCORD_CLIENT_ID=your_discord_client_id
+DISCORD_CLIENT_SECRET=your_discord_client_secret
+
+# ── Client (Vite) ─────────────────────────────────────────────────────────────
+# Create packages/client/.env.local with:
+
+# VITE_DISCORD_CLIENT_ID=your_discord_client_id

--- a/package-lock.json
+++ b/package-lock.json
@@ -2231,6 +2231,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -3256,6 +3263,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/bidi-js": {
@@ -9038,17 +9054,21 @@
       "dependencies": {
         "@colyseus/monitor": "^0.15.0",
         "@durak/shared": "*",
+        "bcryptjs": "^3.0.3",
         "colyseus": "^0.15.0",
         "cors": "^2.8.5",
         "dotenv": "^8.6.0",
         "express": "^4.19.0",
+        "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.6.0",
         "openai": "^6.37.0"
       },
       "devDependencies": {
         "@colyseus/testing": "^0.15.4",
+        "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.10",
         "nodemon": "^3.1.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9053,6 +9053,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@colyseus/monitor": "^0.15.0",
+        "@colyseus/redis-driver": "^0.15.0",
+        "@colyseus/redis-presence": "^0.15.0",
         "@durak/shared": "*",
         "bcryptjs": "^3.0.3",
         "colyseus": "^0.15.0",

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -16,9 +16,19 @@ import { GameLog } from './src/models/GameLog';
 import { User } from './src/models/User';
 
 const JWT_SECRET = process.env.JWT_SECRET;
-if (!JWT_SECRET && process.env.NODE_ENV === 'production') {
-  console.error('FATAL: JWT_SECRET must be set in production');
-  process.exit(1);
+const JWT_PLACEHOLDERS = new Set([
+  'durak-dev-secret-change-in-prod',
+  'change-me-in-production',
+  'secret',
+  '',
+]);
+if (process.env.NODE_ENV === 'production') {
+  if (!JWT_SECRET || JWT_PLACEHOLDERS.has(JWT_SECRET)) {
+    console.error(
+      'FATAL: JWT_SECRET is missing or uses a known insecure placeholder in production',
+    );
+    process.exit(1);
+  }
 }
 const _JWT_SECRET = JWT_SECRET ?? 'durak-dev-secret-change-in-prod';
 

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -15,7 +15,12 @@ import { PlayerProfile } from './src/models/PlayerProfile';
 import { GameLog } from './src/models/GameLog';
 import { User } from './src/models/User';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'durak-dev-secret-change-in-prod';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET && process.env.NODE_ENV === 'production') {
+  console.error('FATAL: JWT_SECRET must be set in production');
+  process.exit(1);
+}
+const _JWT_SECRET = JWT_SECRET ?? 'durak-dev-secret-change-in-prod';
 
 if (process.env.MONGO_URI) {
   mongoose
@@ -107,7 +112,7 @@ app.post('/api/auth/register', async (req, res) => {
       username: username.trim().slice(0, 32),
     });
 
-    const token = jwt.sign({ userId: user._id.toString() }, JWT_SECRET, { expiresIn: '30d' });
+    const token = jwt.sign({ userId: user._id.toString() }, _JWT_SECRET, { expiresIn: '30d' });
     res.status(201).json({
       token,
       user: {
@@ -137,7 +142,7 @@ app.post('/api/auth/login', async (req, res) => {
       return;
     }
 
-    const token = jwt.sign({ userId: user._id.toString() }, JWT_SECRET, { expiresIn: '30d' });
+    const token = jwt.sign({ userId: user._id.toString() }, _JWT_SECRET, { expiresIn: '30d' });
     res.json({
       token,
       user: {
@@ -160,7 +165,7 @@ app.get('/api/auth/me', async (req, res) => {
       res.status(401).json({ error: 'Missing token' });
       return;
     }
-    const payload = jwt.verify(auth.slice(7), JWT_SECRET) as { userId: string };
+    const payload = jwt.verify(auth.slice(7), _JWT_SECRET) as { userId: string };
     const user = await User.findById(payload.userId).select('-passwordHash');
     if (!user) {
       res.status(404).json({ error: 'User not found' });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@colyseus/monitor": "^0.15.0",
+    "@colyseus/redis-driver": "^0.15.0",
+    "@colyseus/redis-presence": "^0.15.0",
     "@durak/shared": "*",
     "bcryptjs": "^3.0.3",
     "colyseus": "^0.15.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,17 +12,21 @@
   "dependencies": {
     "@colyseus/monitor": "^0.15.0",
     "@durak/shared": "*",
+    "bcryptjs": "^3.0.3",
     "colyseus": "^0.15.0",
     "cors": "^2.8.5",
     "dotenv": "^8.6.0",
     "express": "^4.19.0",
+    "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.6.0",
     "openai": "^6.37.0"
   },
   "devDependencies": {
     "@colyseus/testing": "^0.15.4",
+    "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.10",
     "nodemon": "^3.1.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary

- Crash-fast at startup when `JWT_SECRET` is unset in `NODE_ENV=production` — prevents the server from silently falling back to the dev placeholder secret
- All `jwt.sign` / `jwt.verify` calls now use the validated `_JWT_SECRET` binding
- Added `.env.example` documenting every required and optional environment variable with inline comments
- `JWT_SECRET` has already been set on the Fly deployment via `fly secrets set`

## Test plan

- [ ] Local dev starts normally without `JWT_SECRET` (falls back to dev default, warning-free)
- [ ] Setting `NODE_ENV=production` without `JWT_SECRET` causes process to exit with FATAL error
- [ ] Register / login / `/api/auth/me` continue working in dev
- [ ] Review `.env.example` covers all vars used in `index.ts` and `vite.config.ts`

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JWT-backed sign-in, registration, and profile endpoints.

* **Documentation**
  * Added environment configuration template covering server, JWT, Redis, and Discord OAuth settings.

* **Chores**
  * Added runtime and type packages for auth and Redis support.
  * Enforced presence of a secure JWT secret in production.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/186)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->