### PR TITLE
fix(wave-2): security header hardening, Discord ID fallback, Dockerfile build arg, password min

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN npm ci
 COPY . .
 
 # Build frontend assets that server will serve from packages/client/dist
-ENV VITE_DISCORD_CLIENT_ID=1493531312206647406
+ARG VITE_DISCORD_CLIENT_ID
+ENV VITE_DISCORD_CLIENT_ID=$VITE_DISCORD_CLIENT_ID
 RUN npm run build:client
 
 ENV NODE_ENV=production

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,8 @@ primary_region = "iad"
 
 [build]
   dockerfile = "Dockerfile"
+  [build.args]
+    VITE_DISCORD_CLIENT_ID = ""
 
 [env]
   PORT = "2567"

--- a/packages/client/src/discordAuth.ts
+++ b/packages/client/src/discordAuth.ts
@@ -1,6 +1,11 @@
 import { DiscordSDK } from '@discord/embedded-app-sdk';
 
-const clientId = import.meta.env.VITE_DISCORD_CLIENT_ID || '123456789012345678';
+const clientId: string = import.meta.env.VITE_DISCORD_CLIENT_ID;
+if (!clientId) {
+  console.error(
+    'VITE_DISCORD_CLIENT_ID is not set — Discord auth will not work. Add it to packages/client/.env.local',
+  );
+}
 
 export const isEmbedded =
   window.location.search.includes('frame_id') || document.referrer.includes('discord.com');

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -76,9 +76,18 @@ app.set('trust proxy', 1);
 app.use(cors());
 app.use(express.json());
 
-// Issue #69: Allow Discord to embed this application in an iframe
 app.use((req, res, next) => {
-  res.setHeader('Content-Security-Policy', 'frame-ancestors *');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  // API routes don't need iframe embedding
+  if (req.path.startsWith('/api') || req.path.startsWith('/matchmake')) {
+    res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+  } else {
+    // Allow Discord and localhost to embed the Activity
+    res.setHeader(
+      'Content-Security-Policy',
+      'frame-ancestors https://*.discord.com https://discord.com http://localhost:*',
+    );
+  }
   res.setHeader('Access-Control-Allow-Origin', '*');
   next();
 });
@@ -136,8 +145,8 @@ app.post('/api/auth/register', async (req, res) => {
       res.status(400).json({ error: 'email, password, and username are required' });
       return;
     }
-    if (password.length < 6) {
-      res.status(400).json({ error: 'Password must be at least 6 characters' });
+    if (password.length < 8) {
+      res.status(400).json({ error: 'Password must be at least 8 characters' });
       return;
     }
 


### PR DESCRIPTION
## Summary

Four Wave 2 security hardening items. Stacked on top of `wave-1-infra` (#207).

- **Closes #188** — `frame-ancestors` scoped to Discord origins on HTML routes, `'none'` on API/matchmake routes; `X-Content-Type-Options: nosniff` added globally
- **Closes #187** — hardcoded `'123456789012345678'` fallback removed from `discordAuth.ts`; logs a clear console error at startup if `VITE_DISCORD_CLIENT_ID` is unset
- **Closes #192** — `VITE_DISCORD_CLIENT_ID` moved from `ENV` to `ARG` in `Dockerfile`; `[build.args]` added to `fly.toml` so the image is environment-agnostic
- **Closes #191** — password minimum raised from 6 → 8 characters

## Test plan

- [ ] `npm run lint` — 0 errors ✅
- [ ] `npm test` — 139/139 pass ✅
- [ ] API routes return `Content-Security-Policy: frame-ancestors 'none'`
- [ ] HTML routes return `frame-ancestors https://*.discord.com ...`
- [ ] Missing `VITE_DISCORD_CLIENT_ID` at build time logs an error (doesn't silently use wrong app ID)
- [ ] Registration rejects passwords shorter than 8 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased minimum password length requirement from 6 to 8 characters for stronger account security.
  * Enhanced security headers to prevent MIME type sniffing and implemented stricter iframe embedding restrictions.

* **Chores**
  * Updated build configuration to support environment-based Discord authentication setup.
  * Added runtime validation for missing Discord client configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/208)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->