### PR TITLE
Refactor DurakRoom card removal to be more optimal

### DIFF
--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -814,13 +814,23 @@ export class DurakRoom extends Room<GameState> {
     this.broadcast('clearDefenseSnapshot');
 
     // Move cards from hand to active attack
-    cardsToPlay.forEach((c) => {
-      const idx = player.hand.findIndex((hc) => hc.suit === c.suit && hc.rank === c.rank);
-      if (idx !== -1) {
-        player.hand.splice(idx, 1);
-        this.state.activeAttackCards.push(c);
+    const attackCounts = new Map<string, number>();
+    for (const c of cardsToPlay) {
+      const key = `${c.suit}:${c.rank}`;
+      attackCounts.set(key, (attackCounts.get(key) || 0) + 1);
+    }
+
+    for (let i = player.hand.length - 1; i >= 0; i--) {
+      const hc = player.hand[i];
+      if (!hc) continue;
+      const key = `${hc.suit}:${hc.rank}`;
+      const count = attackCounts.get(key) || 0;
+      if (count > 0) {
+        attackCounts.set(key, count - 1);
+        player.hand.splice(i, 1);
+        this.state.activeAttackCards.push(new Card(hc.suit, hc.rank, hc.isJoker));
       }
-    });
+    }
 
     const playedLog = cardsToPlay.map((c) => `-${this.formatCard(c)}`).join(', ');
     this.state.actionLog.push(`${client.sessionId} attacked: ${playedLog}`);
@@ -903,16 +913,24 @@ export class DurakRoom extends Room<GameState> {
     this.state.activeAttackCards.splice(0, this.state.activeAttackCards.length);
 
     // The matched defense cards become the NEW activeAttackCards (next player must beat these)
-    assignments.forEach((pair) => {
+    const defendCounts = new Map<string, number>();
+    for (const pair of assignments) {
       const defCard = pair.def;
-      const idx = player.hand.findIndex(
-        (hc) => hc.suit === defCard.suit && hc.rank === defCard.rank,
-      );
-      if (idx !== -1) {
-        player.hand.splice(idx, 1);
-        this.state.activeAttackCards.push(new Card(defCard.suit, defCard.rank, defCard.isJoker));
+      const key = `${defCard.suit}:${defCard.rank}`;
+      defendCounts.set(key, (defendCounts.get(key) || 0) + 1);
+    }
+
+    for (let i = player.hand.length - 1; i >= 0; i--) {
+      const hc = player.hand[i];
+      if (!hc) continue;
+      const key = `${hc.suit}:${hc.rank}`;
+      const count = defendCounts.get(key) || 0;
+      if (count > 0) {
+        defendCounts.set(key, count - 1);
+        player.hand.splice(i, 1);
+        this.state.activeAttackCards.push(new Card(hc.suit, hc.rank, hc.isJoker));
       }
-    });
+    }
 
     const defLog = defendingCards.map((c) => `-${this.formatCard(c)}`).join(', ');
     this.state.actionLog.push(`${client.sessionId} defended: ${defLog}`);


### PR DESCRIPTION
Replaced nested array searches (`findIndex` inside loops) with O(N+M) frequency maps when removing cards from a player's hand during attack and defense phases. Used a backward iteration over the hand array to safely remove elements with `.splice()`, avoiding issues with shifting indices.

---
*PR created automatically by Jules for task [7689868165736517004](https://jules.google.com/task/7689868165736517004) started by @turbo-leg*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced card removal logic during attack and defense actions to properly handle duplicate cards in player hands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/213)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->