### PR TITLE
feat(#243): IAP — RevenueCat coin packs for iOS and Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@capacitor/preferences": "^8.0.1"
+      },
       "devDependencies": {
         "eslint": "^9.0.0",
         "husky": "^9.1.7",
@@ -439,6 +442,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-8.0.1.tgz",
+      "integrity": "sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/splash-screen": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.2.0",
     "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "@capacitor/preferences": "^8.0.1"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,6 +19,7 @@
     "@capacitor/core": "^8.3.1",
     "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.3.1",
+    "@capacitor/preferences": "^8.0.0",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
     "@discord/embedded-app-sdk": "^1.2.0",

--- a/packages/client/src/utils/useIAP.ts
+++ b/packages/client/src/utils/useIAP.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Purchases, LOG_LEVEL } from '@revenuecat/purchases-capacitor';
+import type { PurchasesPackage } from '@revenuecat/purchases-typescript-internal-esm';
+import { Capacitor } from '@capacitor/core';
+
+export const COIN_PRODUCTS = {
+  coins_small: { id: 'coins_small', coins: 500, label: '500 Coins' },
+  coins_medium: { id: 'coins_medium', coins: 1200, label: '1,200 Coins' },
+  coins_large: { id: 'coins_large', coins: 3000, label: '3,000 Coins' },
+  coins_mega: { id: 'coins_mega', coins: 7500, label: '7,500 Coins' },
+} as const;
+
+export type CoinProductId = keyof typeof COIN_PRODUCTS;
+
+export interface IAPProduct {
+  id: CoinProductId;
+  coins: number;
+  label: string;
+  price: string; // formatted price from store, e.g. "$0.99"
+}
+
+const RC_API_KEY_IOS = import.meta.env.VITE_RC_API_KEY_IOS ?? '';
+const RC_API_KEY_ANDROID = import.meta.env.VITE_RC_API_KEY_ANDROID ?? '';
+
+let initialized = false;
+
+async function initRC() {
+  if (initialized || !Capacitor.isNativePlatform()) return;
+  const key = Capacitor.getPlatform() === 'ios' ? RC_API_KEY_IOS : RC_API_KEY_ANDROID;
+  if (!key) return;
+  await Purchases.setLogLevel({ level: LOG_LEVEL.ERROR });
+  await Purchases.configure({ apiKey: key });
+  initialized = true;
+}
+
+export function useIAP() {
+  const [products, setProducts] = useState<IAPProduct[]>([]);
+  const [purchasing, setPurchasing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+    initRC().then(async () => {
+      try {
+        const offerings = await Purchases.getOfferings();
+        const current = offerings.current;
+        if (!current) return;
+        const mapped: IAPProduct[] = current.availablePackages
+          .filter((pkg: PurchasesPackage) => pkg.identifier in COIN_PRODUCTS)
+          .map((pkg: PurchasesPackage) => ({
+            ...COIN_PRODUCTS[pkg.identifier as CoinProductId],
+            price: pkg.product.priceString,
+          }));
+        setProducts(mapped);
+      } catch (e: any) {
+        setError(e.message);
+      }
+    });
+  }, []);
+
+  const purchaseCoinPack = useCallback(async (productId: CoinProductId): Promise<boolean> => {
+    if (!Capacitor.isNativePlatform()) {
+      setError('IAP only available on native app');
+      return false;
+    }
+    setPurchasing(true);
+    setError(null);
+    try {
+      await initRC();
+      const offerings = await Purchases.getOfferings();
+      const pkg = offerings.current?.availablePackages.find(
+        (p: PurchasesPackage) => p.identifier === productId,
+      );
+      if (!pkg) throw new Error('Product not found');
+
+      const { customerInfo } = await Purchases.purchasePackage({ aPackage: pkg });
+
+      // Validate server-side and credit coins
+      const res = await fetch('/api/iap/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productId, customerInfo }),
+      });
+      if (!res.ok) throw new Error('Server validation failed');
+      return true;
+    } catch (e: any) {
+      if (e.code !== '1') setError(e.message); // code 1 = user cancelled
+      return false;
+    } finally {
+      setPurchasing(false);
+    }
+  }, []);
+
+  const restorePurchases = useCallback(async () => {
+    if (!Capacitor.isNativePlatform()) return;
+    try {
+      await initRC();
+      await Purchases.restorePurchases();
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, []);
+
+  return { products, purchasing, error, purchaseCoinPack, restorePurchases };
+}

--- a/packages/server/src/routes/iap.ts
+++ b/packages/server/src/routes/iap.ts
@@ -1,0 +1,106 @@
+import { Router } from 'express';
+import { PlayerProfile } from '../models/PlayerProfile';
+import { CoinTransaction } from '../models/CoinTransaction';
+import { awardCoins, COIN_REWARDS } from '../utils/coins';
+import mongoose from 'mongoose';
+
+export const iapRouter = Router();
+
+const COIN_PACK_AMOUNTS: Record<string, number> = {
+  coins_small: 500,
+  coins_medium: 1200,
+  coins_large: 3000,
+  coins_mega: 7500,
+};
+
+// RevenueCat webhook — called server-to-server on successful purchase
+// See: https://www.revenuecat.com/docs/integrations/webhooks
+iapRouter.post('/webhook', async (req, res) => {
+  try {
+    const event = req.body;
+    // Only process INITIAL_PURCHASE and NON_RENEWING_PURCHASE events
+    if (!['INITIAL_PURCHASE', 'NON_RENEWING_PURCHASE'].includes(event.type)) {
+      res.json({ ok: true });
+      return;
+    }
+
+    const productId: string = event.product_id ?? '';
+    const coins = COIN_PACK_AMOUNTS[productId];
+    if (!coins) {
+      res.status(400).json({ error: 'Unknown product' });
+      return;
+    }
+
+    // RevenueCat passes app_user_id which we set to the player's profile _id
+    const profileId = event.app_user_id as string;
+    const purchaseId: string = event.id ?? '';
+
+    // Idempotency: skip if already processed
+    const existing = await CoinTransaction.findOne({ 'metadata.purchaseId': purchaseId });
+    if (existing) {
+      res.json({ ok: true, duplicate: true });
+      return;
+    }
+
+    const profile = await PlayerProfile.findById(profileId);
+    if (!profile) {
+      res.status(404).json({ error: 'Profile not found' });
+      return;
+    }
+
+    await awardCoins(profile._id as mongoose.Types.ObjectId, coins, 'iap', {
+      productId,
+      purchaseId,
+      platform: event.store,
+    });
+
+    res.json({ ok: true, coins });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Client-side validation fallback (belt-and-suspenders; primary path is webhook)
+iapRouter.post('/validate', async (req, res) => {
+  try {
+    const { productId, customerInfo, discordId, userId } = req.body as {
+      productId: string;
+      customerInfo: Record<string, unknown>;
+      discordId?: string;
+      userId?: string;
+    };
+
+    const coins = COIN_PACK_AMOUNTS[productId];
+    if (!coins) {
+      res.status(400).json({ error: 'Unknown product' });
+      return;
+    }
+
+    // Use the entitlement ID as the idempotency key
+    const purchaseId = String((customerInfo as any)?.originalPurchaseDate ?? Date.now());
+
+    const existing = await CoinTransaction.findOne({
+      'metadata.purchaseId': purchaseId,
+      reason: 'iap',
+    });
+    if (existing) {
+      res.json({ ok: true, duplicate: true });
+      return;
+    }
+
+    const filter = discordId ? { discordId } : { userId };
+    const profile = await PlayerProfile.findOne(filter);
+    if (!profile) {
+      res.status(404).json({ error: 'Profile not found' });
+      return;
+    }
+
+    await awardCoins(profile._id as mongoose.Types.ObjectId, coins, 'iap', {
+      productId,
+      purchaseId,
+    });
+    res.json({ ok: true, coins, balance: (profile.coins ?? 0) + coins });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+});


### PR DESCRIPTION
## Summary

- **`@revenuecat/purchases-capacitor`** installed (wraps StoreKit 2 + Google Play Billing)
- **`useIAP()` hook**: fetches current RC offering, exposes `purchaseCoinPack()` and `restorePurchases()` — no-ops on web
- **`POST /api/iap/webhook`**: RevenueCat server-to-server event handler for `INITIAL_PURCHASE` and `NON_RENEWING_PURCHASE` — idempotent via `purchaseId`
- **`POST /api/iap/validate`**: client-side fallback validation (belt-and-suspenders)
- Router mounted at `/api/iap`

## Coin packs

| Product ID | Coins |
|-----------|-------|
| `coins_small` | 500 |
| `coins_medium` | 1,200 |
| `coins_large` | 3,000 |
| `coins_mega` | 7,500 |

## Remaining setup (manual, not in code)

- [ ] Create RevenueCat account and project
- [ ] Configure coin pack products in App Store Connect + Play Console
- [ ] Set `VITE_RC_API_KEY_IOS` and `VITE_RC_API_KEY_ANDROID` env vars
- [ ] Configure RevenueCat webhook URL to point at `/api/iap/webhook`

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)