### PR TITLE
feat(#244): in-game shop — buy cosmetics with coins

### DIFF
--- a/packages/client/src/components/ShopScreen.tsx
+++ b/packages/client/src/components/ShopScreen.tsx
@@ -1,0 +1,198 @@
+import React, { useEffect, useState, useCallback } from 'react';
+
+interface ShopItem {
+  id: string;
+  name: string;
+  type: 'card_back' | 'avatar_frame' | 'emote';
+  price: number;
+  preview: string;
+}
+
+interface Props {
+  discordId?: string;
+  userId?: string;
+}
+
+const API = '/api';
+const TYPE_LABELS: Record<ShopItem['type'], string> = {
+  card_back: 'Card Backs',
+  avatar_frame: 'Avatar Frames',
+  emote: 'Emotes',
+};
+const TYPE_ORDER: ShopItem['type'][] = ['card_back', 'avatar_frame', 'emote'];
+
+export const ShopScreen: React.FC<Props> = ({ discordId, userId }) => {
+  const [items, setItems] = useState<ShopItem[]>([]);
+  const [balance, setBalance] = useState<number | null>(null);
+  const [ownedItems, setOwnedItems] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [purchasing, setPurchasing] = useState<string | null>(null);
+  const [purchaseMsg, setPurchaseMsg] = useState<string | null>(null);
+
+  const id = discordId ?? userId ?? '';
+  const byParam = userId && !discordId ? 'by=user' : '';
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      fetch(`${API}/shop/items`).then((r) => (r.ok ? (r.json() as Promise<ShopItem[]>) : [])),
+      fetch(`${API}/profile/${id}${byParam ? `?${byParam}` : ''}`).then((r) =>
+        r.ok ? (r.json() as Promise<{ coins: number; ownedItems?: string[] }>) : null,
+      ),
+    ])
+      .then(([shopItems, profile]) => {
+        if (cancelled) return;
+        setItems(Array.isArray(shopItems) ? shopItems : []);
+        setBalance(profile?.coins ?? null);
+        setOwnedItems(profile?.ownedItems ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load shop. Please try again.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, byParam]);
+
+  const handleBuy = useCallback(
+    async (item: ShopItem) => {
+      if (!id) return;
+      setPurchasing(item.id);
+      setPurchaseMsg(null);
+      try {
+        const body: Record<string, string> = { itemId: item.id };
+        if (discordId) body.discordId = discordId;
+        else if (userId) body.userId = userId;
+
+        const res = await fetch(`${API}/shop/purchase`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const data = (await res.json()) as {
+          ok?: boolean;
+          balance?: number;
+          ownedItems?: string[];
+          error?: string;
+        };
+
+        if (!res.ok || !data.ok) {
+          setPurchaseMsg(data.error ?? 'Purchase failed.');
+        } else {
+          setBalance(data.balance ?? null);
+          setOwnedItems(data.ownedItems ?? []);
+          setPurchaseMsg(`Purchased ${item.name}!`);
+        }
+      } catch {
+        setPurchaseMsg('Network error. Please try again.');
+      } finally {
+        setPurchasing(null);
+      }
+    },
+    [id, discordId, userId],
+  );
+
+  if (loading) {
+    return (
+      <div className="text-indigo-400 text-sm text-center py-6 animate-pulse">Loading shop…</div>
+    );
+  }
+
+  if (error) {
+    return <div className="text-red-400 text-sm text-center py-6">{error}</div>;
+  }
+
+  const grouped = TYPE_ORDER.reduce<Record<ShopItem['type'], ShopItem[]>>(
+    (acc, type) => {
+      acc[type] = items.filter((i) => i.type === type);
+      return acc;
+    },
+    { card_back: [], avatar_frame: [], emote: [] },
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Coin balance */}
+      <div className="flex items-center gap-2 bg-indigo-900/60 rounded-lg px-4 py-2">
+        <span className="text-yellow-400 text-lg">🪙</span>
+        <span className="text-white font-bold text-lg">
+          {balance !== null ? balance.toLocaleString() : '—'}
+        </span>
+        <span className="text-indigo-400 text-xs">coins</span>
+      </div>
+
+      {purchaseMsg && (
+        <div
+          className={`text-xs px-3 py-2 rounded ${
+            purchaseMsg.startsWith('Purchased')
+              ? 'bg-green-900/60 text-green-300'
+              : 'bg-red-900/60 text-red-300'
+          }`}
+        >
+          {purchaseMsg}
+        </div>
+      )}
+
+      {/* Item groups */}
+      {TYPE_ORDER.map((type) => {
+        const group = grouped[type];
+        if (group.length === 0) return null;
+        return (
+          <div key={type}>
+            <div className="text-indigo-400 text-xs font-semibold mb-2">{TYPE_LABELS[type]}</div>
+            <div className="grid grid-cols-2 gap-2">
+              {group.map((item) => {
+                const owned = ownedItems.includes(item.id);
+                const isBuying = purchasing === item.id;
+                const canAfford = balance !== null && balance >= item.price;
+                return (
+                  <div
+                    key={item.id}
+                    className="bg-indigo-900/60 border border-indigo-700 rounded-lg p-3 flex flex-col items-center gap-2 text-center"
+                  >
+                    <div className="text-2xl">{item.preview}</div>
+                    <div className="text-white text-xs font-semibold leading-tight">
+                      {item.name}
+                    </div>
+                    <div className="flex items-center gap-1 text-yellow-400 text-xs font-bold">
+                      <span>🪙</span>
+                      <span>{item.price}</span>
+                    </div>
+                    {owned ? (
+                      <span className="text-xs bg-green-800/70 text-green-300 rounded-full px-2 py-0.5 font-semibold">
+                        Owned
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => handleBuy(item)}
+                        disabled={isBuying || !canAfford}
+                        className={`text-xs px-3 py-1 rounded font-semibold transition ${
+                          isBuying
+                            ? 'bg-indigo-700 text-indigo-400 cursor-wait'
+                            : canAfford
+                              ? 'bg-indigo-600 hover:bg-indigo-500 text-white'
+                              : 'bg-indigo-900 text-indigo-500 cursor-not-allowed'
+                        }`}
+                      >
+                        {isBuying ? '…' : canAfford ? 'Buy' : 'Need coins'}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/server/src/routes/shop.ts
+++ b/packages/server/src/routes/shop.ts
@@ -1,0 +1,112 @@
+import { Router, type Request, type Response } from 'express';
+import { PlayerProfile } from '../models/PlayerProfile';
+import { CoinTransaction } from '../models/CoinTransaction';
+
+export const shopRouter = Router();
+
+interface ShopItem {
+  id: string;
+  name: string;
+  type: 'card_back' | 'avatar_frame' | 'emote';
+  price: number;
+  preview: string;
+}
+
+const SHOP_CATALOG: ShopItem[] = [
+  { id: 'card_back_gold', name: 'Gold Card Back', type: 'card_back', price: 500, preview: 'gold' },
+  { id: 'card_back_dark', name: 'Dark Card Back', type: 'card_back', price: 300, preview: 'dark' },
+  {
+    id: 'card_back_ocean',
+    name: 'Ocean Card Back',
+    type: 'card_back',
+    price: 400,
+    preview: 'ocean',
+  },
+  {
+    id: 'frame_gold',
+    name: 'Gold Avatar Frame',
+    type: 'avatar_frame',
+    price: 750,
+    preview: 'gold',
+  },
+  {
+    id: 'frame_diamond',
+    name: 'Diamond Frame',
+    type: 'avatar_frame',
+    price: 1500,
+    preview: 'diamond',
+  },
+  { id: 'emote_laugh', name: 'Laugh Emote', type: 'emote', price: 200, preview: '😂' },
+  { id: 'emote_gg', name: 'GG Emote', type: 'emote', price: 200, preview: '🤝' },
+  { id: 'emote_fire', name: 'Fire Emote', type: 'emote', price: 250, preview: '🔥' },
+];
+
+const ITEM_MAP = new Map<string, ShopItem>(SHOP_CATALOG.map((item) => [item.id, item]));
+
+shopRouter.get('/items', (_req: Request, res: Response) => {
+  res.json(SHOP_CATALOG);
+});
+
+shopRouter.post('/purchase', async (req: Request, res: Response) => {
+  const { discordId, userId, itemId } = req.body as {
+    discordId?: string;
+    userId?: string;
+    itemId?: string;
+  };
+
+  if (!itemId) {
+    res.status(400).json({ error: 'itemId is required' });
+    return;
+  }
+
+  if (!discordId && !userId) {
+    res.status(400).json({ error: 'discordId or userId is required' });
+    return;
+  }
+
+  const item = ITEM_MAP.get(itemId);
+  if (!item) {
+    res.status(404).json({ error: 'Item not found' });
+    return;
+  }
+
+  const query = discordId ? { discordId } : { userId };
+  const profile = await PlayerProfile.findOne(query);
+  if (!profile) {
+    res.status(404).json({ error: 'Player profile not found' });
+    return;
+  }
+
+  if (profile.ownedItems.includes(itemId)) {
+    res.status(400).json({ error: 'Item already owned' });
+    return;
+  }
+
+  if (profile.coins < item.price) {
+    res.status(400).json({ error: 'Insufficient coins' });
+    return;
+  }
+
+  const [updated] = await Promise.all([
+    PlayerProfile.findByIdAndUpdate(
+      profile._id,
+      {
+        $inc: { coins: -item.price },
+        $push: { ownedItems: itemId },
+      },
+      { new: true },
+    ),
+    CoinTransaction.create({
+      playerId: profile._id,
+      amount: -item.price,
+      reason: 'purchase',
+      metadata: { itemId },
+    }),
+  ]);
+
+  res.json({
+    ok: true,
+    balance: updated?.coins ?? profile.coins - item.price,
+    ownedItems: updated?.ownedItems ?? [...profile.ownedItems, itemId],
+  });
+});


### PR DESCRIPTION
## Summary

- **`GET /api/shop/items`**: returns 8 hardcoded cosmetic items (3 card backs, 2 avatar frames, 3 emotes)
- **`POST /api/shop/purchase`**: validates ownership + balance → deducts coins atomically + appends `itemId` to `profile.ownedItems` + logs `CoinTransaction`
- **`ShopScreen.tsx`**: grouped item grid with live coin balance, Buy/Owned/Need-coins states
- **PlayerProfilePanel**: 🛒 shop tab renders `ShopScreen`

## Catalog

| Type | Items |
|------|-------|
| Card Backs | Gold (500), Dark (300), Ocean (400) |
| Avatar Frames | Gold (750), Diamond (1500) |
| Emotes | Laugh (200), GG (200), Fire (250) |

## Test plan

- [ ] `npm run test -w @durak/server` — 66 tests pass
- [ ] Open profile panel → Shop tab → items render
- [ ] Buy an item → balance decreases, "Owned" badge appears
- [ ] Try buying with insufficient coins → button shows "Need coins" (disabled)
- [ ] Buy same item twice → 400 "already owned"

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)