### PR TITLE
feat(mobile-auth): standalone auth flow — email/password + guest mode

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,7 +1,9 @@
 import { useGame } from './contexts/GameContext';
 import { useEffect, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { GameBoard } from './components/GameBoard';
 import { Lobby } from './components/Lobby';
+import { MobileLoginScreen } from './components/MobileLoginScreen';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { isEmbedded, setupDiscordSdk, discordSdk, type DiscordAuthInfo } from './discordAuth';
 import { useAuth } from './contexts/AuthContext';
@@ -164,8 +166,10 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
 function App() {
   const [auth, setAuth] = useState<DiscordAuthInfo | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
+  const { user, isLoading: authLoading } = useAuth();
 
   useEffect(() => {
+    // Discord embedded SDK setup — only when running as a Discord Activity
     if (isEmbedded) {
       setupDiscordSdk()
         .then((discordAuth) => {
@@ -177,6 +181,15 @@ function App() {
         });
     }
   }, []);
+
+  // On native mobile: show full-screen login until the user authenticates
+  if (Capacitor.isNativePlatform() && !authLoading && !user) {
+    return (
+      <ErrorBoundary>
+        <MobileLoginScreen />
+      </ErrorBoundary>
+    );
+  }
 
   return (
     <ErrorBoundary>

--- a/packages/client/src/components/MobileLoginScreen.tsx
+++ b/packages/client/src/components/MobileLoginScreen.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+type Mode = 'login' | 'register';
+
+export const MobileLoginScreen: React.FC = () => {
+  const { isLoading, error, loginWithEmail, registerWithEmail } = useAuth();
+  const [mode, setMode] = useState<Mode>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const displayError = localError || error;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    try {
+      if (mode === 'login') {
+        await loginWithEmail(email, password);
+      } else {
+        if (!username.trim()) {
+          setLocalError('Username is required');
+          return;
+        }
+        if (password.length < 8) {
+          setLocalError('Password must be at least 8 characters');
+          return;
+        }
+        await registerWithEmail(email, password, username);
+      }
+    } catch {
+      // error already set in context
+    }
+  };
+
+  const handleGuest = async () => {
+    setLocalError(null);
+    const guestUsername = `guest_${Math.random().toString(36).slice(2, 9)}`;
+    const guestEmail = `${guestUsername}@guest.durak.local`;
+    const guestPassword = crypto.randomUUID();
+    try {
+      await registerWithEmail(guestEmail, guestPassword, guestUsername);
+    } catch {
+      setLocalError('Could not create guest session. Please try again.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-purple-950 flex flex-col items-center justify-center p-6">
+      <div className="w-full max-w-sm">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-extrabold text-white tracking-tight drop-shadow-md">
+            ♦ Durak <span className="text-yellow-400">Online</span> ♦
+          </h1>
+          <p className="text-purple-400 text-sm mt-2">Multiplayer card game</p>
+        </div>
+
+        {/* Card */}
+        <div className="bg-purple-900/60 border border-purple-700 rounded-2xl p-6 shadow-2xl backdrop-blur-sm">
+          {/* Mode tabs */}
+          <div className="flex gap-2 mb-5">
+            {(['login', 'register'] as Mode[]).map((m) => (
+              <button
+                key={m}
+                onClick={() => {
+                  setMode(m);
+                  setLocalError(null);
+                }}
+                className={`flex-1 py-2 rounded-lg text-sm font-semibold transition ${
+                  mode === m
+                    ? 'bg-purple-600 text-white shadow'
+                    : 'bg-purple-800/50 text-purple-300 hover:bg-purple-700/50'
+                }`}
+              >
+                {m === 'login' ? 'Sign In' : 'Sign Up'}
+              </button>
+            ))}
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="space-y-3">
+            {mode === 'register' && (
+              <input
+                type="text"
+                placeholder="Username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="w-full bg-purple-800/60 border border-purple-600 text-white placeholder-purple-400 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-purple-400 focus:ring-1 focus:ring-purple-400"
+                maxLength={32}
+                autoCapitalize="none"
+                autoCorrect="off"
+              />
+            )}
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full bg-purple-800/60 border border-purple-600 text-white placeholder-purple-400 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-purple-400 focus:ring-1 focus:ring-purple-400"
+              autoCapitalize="none"
+              autoCorrect="off"
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full bg-purple-800/60 border border-purple-600 text-white placeholder-purple-400 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-purple-400 focus:ring-1 focus:ring-purple-400"
+            />
+
+            {displayError && <p className="text-red-400 text-xs px-1">{displayError}</p>}
+
+            <button
+              type="submit"
+              disabled={isLoading || !email || !password}
+              className="w-full bg-yellow-500 hover:bg-yellow-400 disabled:opacity-50 text-purple-950 font-bold py-3 rounded-xl transition shadow-lg"
+            >
+              {isLoading ? 'Loading…' : mode === 'login' ? 'Sign In' : 'Create Account'}
+            </button>
+          </form>
+
+          {/* Divider */}
+          <div className="flex items-center gap-3 my-4">
+            <div className="flex-1 h-px bg-purple-700" />
+            <span className="text-purple-500 text-xs">or</span>
+            <div className="flex-1 h-px bg-purple-700" />
+          </div>
+
+          {/* Guest */}
+          <button
+            onClick={handleGuest}
+            disabled={isLoading}
+            className="w-full bg-purple-800/60 hover:bg-purple-700/60 disabled:opacity-50 text-purple-200 font-semibold py-3 rounded-xl border border-purple-600 transition"
+          >
+            Continue as Guest
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/client/src/contexts/AuthContext.tsx
+++ b/packages/client/src/contexts/AuthContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, useContext, useState, useCallback } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { storage } from '../utils/storage';
 
 const CLIENT_ID = import.meta.env.VITE_DISCORD_CLIENT_ID || '123456789012345678';
 const STORAGE_KEY = 'durak_auth';
@@ -22,6 +24,8 @@ interface AuthContextState {
   error: string | null;
   loginWithDiscord: () => void;
   loginWithEmail: (email: string, password: string) => Promise<void>;
+  registerWithEmail: (email: string, password: string, username: string) => Promise<void>;
+  /** @deprecated Use registerWithEmail instead */
   register: (email: string, password: string, username: string) => Promise<void>;
   logout: () => void;
   handleOAuthCallback: (code: string) => Promise<void>;
@@ -33,6 +37,7 @@ const AuthContext = createContext<AuthContextState>({
   error: null,
   loginWithDiscord: () => {},
   loginWithEmail: async () => {},
+  registerWithEmail: async () => {},
   register: async () => {},
   logout: () => {},
   handleOAuthCallback: async () => {},
@@ -47,7 +52,10 @@ function buildAvatarUrl(id: string, hash: string | null): string {
 }
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  // On web, seed initial state synchronously from localStorage.
+  // On native, start null and hydrate asynchronously in the effect below.
   const [user, setUser] = useState<AuthUser | null>(() => {
+    if (Capacitor.isNativePlatform()) return null;
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
       try {
@@ -58,14 +66,36 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
     return null;
   });
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(Capacitor.isNativePlatform());
   const [error, setError] = useState<string | null>(null);
 
-  const persist = (u: AuthUser | null) => {
-    if (u) localStorage.setItem(STORAGE_KEY, JSON.stringify(u));
-    else localStorage.removeItem(STORAGE_KEY);
+  // Hydrate auth state from async storage on native platforms
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+    storage
+      .get(STORAGE_KEY)
+      .then((saved) => {
+        if (saved) {
+          try {
+            setUser(JSON.parse(saved) as AuthUser);
+          } catch {
+            void storage.remove(STORAGE_KEY);
+          }
+        }
+      })
+      .catch((e: unknown) => {
+        console.error('Failed to load auth from storage:', e);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const persist = useCallback((u: AuthUser | null) => {
+    const save = u ? storage.set(STORAGE_KEY, JSON.stringify(u)) : storage.remove(STORAGE_KEY);
+    save.catch((e: unknown) => console.error('Failed to persist auth:', e));
     setUser(u);
-  };
+  }, []);
 
   const loginWithDiscord = useCallback(() => {
     const params = new URLSearchParams({
@@ -77,107 +107,116 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     window.location.href = `https://discord.com/api/oauth2/authorize?${params}`;
   }, []);
 
-  const handleOAuthCallback = useCallback(async (code: string) => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const tokenRes = await fetch('/api/token', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code, redirect_uri: REDIRECT_URI }),
-      });
-      const tokenData = await tokenRes.json();
-      if (!tokenRes.ok) {
-        const msg = tokenData?.error_description || tokenData?.error || 'Token exchange failed';
-        throw new Error(msg);
+  const handleOAuthCallback = useCallback(
+    async (code: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const tokenRes = await fetch('/api/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, redirect_uri: REDIRECT_URI }),
+        });
+        const tokenData = await tokenRes.json();
+        if (!tokenRes.ok) {
+          const msg = tokenData?.error_description || tokenData?.error || 'Token exchange failed';
+          throw new Error(msg);
+        }
+        const { access_token } = tokenData;
+
+        const meRes = await fetch('https://discord.com/api/users/@me', {
+          headers: { Authorization: `Bearer ${access_token}` },
+        });
+        if (!meRes.ok) throw new Error('Failed to fetch Discord user');
+        const me = await meRes.json();
+
+        persist({
+          id: me.id,
+          method: 'discord',
+          username: me.username,
+          globalName: me.global_name ?? null,
+          avatarUrl: buildAvatarUrl(me.id, me.avatar),
+          token: access_token,
+        });
+
+        window.history.replaceState({}, '', window.location.pathname);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Discord login failed');
+      } finally {
+        setIsLoading(false);
       }
-      const { access_token } = tokenData;
+    },
+    [persist],
+  );
 
-      const meRes = await fetch('https://discord.com/api/users/@me', {
-        headers: { Authorization: `Bearer ${access_token}` },
-      });
-      if (!meRes.ok) throw new Error('Failed to fetch Discord user');
-      const me = await meRes.json();
+  const loginWithEmail = useCallback(
+    async (email: string, password: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Login failed');
 
-      persist({
-        id: me.id,
-        method: 'discord',
-        username: me.username,
-        globalName: me.global_name ?? null,
-        avatarUrl: buildAvatarUrl(me.id, me.avatar),
-        token: access_token,
-      });
+        persist({
+          id: data.user.id,
+          method: 'email',
+          username: data.user.username,
+          globalName: null,
+          avatarUrl: data.user.avatarUrl || '',
+          email: data.user.email,
+          token: data.token,
+        });
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Login failed');
+        throw e;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [persist],
+  );
 
-      window.history.replaceState({}, '', window.location.pathname);
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Discord login failed');
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const registerWithEmail = useCallback(
+    async (email: string, password: string, username: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password, username }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Registration failed');
 
-  const loginWithEmail = useCallback(async (email: string, password: string) => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Login failed');
-
-      persist({
-        id: data.user.id,
-        method: 'email',
-        username: data.user.username,
-        globalName: null,
-        avatarUrl: data.user.avatarUrl || '',
-        email: data.user.email,
-        token: data.token,
-      });
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Login failed');
-      throw e;
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  const register = useCallback(async (email: string, password: string, username: string) => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const res = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password, username }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Registration failed');
-
-      persist({
-        id: data.user.id,
-        method: 'email',
-        username: data.user.username,
-        globalName: null,
-        avatarUrl: data.user.avatarUrl || '',
-        email: data.user.email,
-        token: data.token,
-      });
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Registration failed');
-      throw e;
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+        persist({
+          id: data.user.id,
+          method: 'email',
+          username: data.user.username,
+          globalName: null,
+          avatarUrl: data.user.avatarUrl || '',
+          email: data.user.email,
+          token: data.token,
+        });
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Registration failed');
+        throw e;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [persist],
+  );
 
   const logout = useCallback(() => {
     persist(null);
     setError(null);
-  }, []);
+  }, [persist]);
 
   return (
     <AuthContext.Provider
@@ -187,7 +226,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         error,
         loginWithDiscord,
         loginWithEmail,
-        register,
+        registerWithEmail,
+        register: registerWithEmail,
         logout,
         handleOAuthCallback,
       }}

--- a/packages/client/src/utils/storage.ts
+++ b/packages/client/src/utils/storage.ts
@@ -1,0 +1,33 @@
+import { Capacitor } from '@capacitor/core';
+import { Preferences } from '@capacitor/preferences';
+
+/**
+ * Thin async storage wrapper.
+ * - On native (iOS/Android): delegates to @capacitor/preferences (secure, sandboxed).
+ * - On web: falls back to localStorage wrapped in promises.
+ */
+export const storage = {
+  async get(key: string): Promise<string | null> {
+    if (Capacitor.isNativePlatform()) {
+      const { value } = await Preferences.get({ key });
+      return value;
+    }
+    return localStorage.getItem(key);
+  },
+
+  async set(key: string, value: string): Promise<void> {
+    if (Capacitor.isNativePlatform()) {
+      await Preferences.set({ key, value });
+    } else {
+      localStorage.setItem(key, value);
+    }
+  },
+
+  async remove(key: string): Promise<void> {
+    if (Capacitor.isNativePlatform()) {
+      await Preferences.remove({ key });
+    } else {
+      localStorage.removeItem(key);
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Week 1.2 of the mobile release plan — decouples auth from Discord's embedded SDK so the standalone iOS/Android app has a first-class login experience.

- **`storage.ts`**: async wrapper over `@capacitor/preferences` (native) / `localStorage` (web) with a uniform `{ get, set, remove }` API
- **`MobileLoginScreen.tsx`**: full-screen login/register form with email + password fields, Sign In / Sign Up toggle, and "Continue as Guest" (auto-registers a `guest_<uuid>` account) — no Discord dependency
- **`AuthContext`**: replaces all `localStorage` calls with `storage` util; adds `loginWithEmail` / `registerWithEmail`; async hydration on native with `isLoading` guard so the app doesn't flash before state is known
- **`App.tsx`**: if `Capacitor.isNativePlatform() && !authLoading && !user` → show `MobileLoginScreen`

## What's unchanged

- All Discord Activity code (`isEmbedded`, `setupDiscordSdk`) is untouched
- Web browser flow is unchanged — same localStorage-backed auth

## Test plan

- [ ] `npx tsc -p packages/client/tsconfig.json --noEmit` — no errors
- [ ] Run on iOS simulator — app shows `MobileLoginScreen` on first launch
- [ ] Sign up with email → profile created, persists after app kill/reopen
- [ ] Continue as Guest → game lobby opens immediately
- [ ] Discord Activity in browser → existing flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)