### PR TITLE
feat(mobile): public matchmaking lobby + Play vs Bot settings

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,6 +4,7 @@ import { Capacitor } from '@capacitor/core';
 import { GameBoard } from './components/GameBoard';
 import { Lobby } from './components/Lobby';
 import { MobileLoginScreen } from './components/MobileLoginScreen';
+import { PublicLobby } from './components/PublicLobby';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { isEmbedded, setupDiscordSdk, discordSdk, type DiscordAuthInfo } from './discordAuth';
 import { useAuth } from './contexts/AuthContext';
@@ -126,6 +127,8 @@ function Game({ discordAuth }: { discordAuth?: DiscordAuthInfo | null }) {
                 Connecting to Discord
               </div>
             </div>
+          ) : Capacitor.isNativePlatform() ? (
+            <PublicLobby />
           ) : (
             <Lobby
               discordId={activeDiscordId}

--- a/packages/client/src/components/Lobby.tsx
+++ b/packages/client/src/components/Lobby.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useGame } from '../contexts/GameContext';
+import type { BotOptions } from '../contexts/GameContext';
 import type { RoomAvailable } from 'colyseus.js';
 import { PlayerProfilePanel } from './PlayerProfilePanel';
 import { LoginPanel } from './LoginPanel';
@@ -29,11 +30,16 @@ export const Lobby: React.FC<LobbyProps> = ({
   username = '',
   avatarUrl = '',
 }) => {
-  const { createGame, joinGame, spectateGame, findPublicGames, error } = useGame();
+  const { createGame, joinGame, spectateGame, findPublicGames, playVsBot, error } = useGame();
 
   const [rooms, setRooms] = useState<RoomAvailable[]>([]);
   const [joinCode, setJoinCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  // Bot panel state
+  const [showBotPanel, setShowBotPanel] = useState(false);
+  const [botDifficulty, setBotDifficulty] = useState<BotOptions['difficulty']>('easy');
+  const [botHandSize, setBotHandSize] = useState(5);
 
   // Form options
   const [maxPlayers, setMaxPlayers] = useState(6);
@@ -72,6 +78,13 @@ export const Lobby: React.FC<LobbyProps> = ({
     if (!joinCode.trim()) return;
     setIsLoading(true);
     await joinGame(joinCode.trim(), discordId, userId);
+    setIsLoading(false);
+  };
+
+  const handleStartBot = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    await playVsBot(discordId, userId, { difficulty: botDifficulty, handSize: botHandSize });
     setIsLoading(false);
   };
 
@@ -202,6 +215,57 @@ export const Lobby: React.FC<LobbyProps> = ({
             avatarUrl={avatarUrl}
           />
         )}
+
+        {/* Play vs Bot */}
+        <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-200">
+          <button
+            onClick={() => setShowBotPanel((v) => !v)}
+            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-3 px-4 rounded-lg shadow transition"
+          >
+            🤖 Play vs Bot
+          </button>
+
+          {showBotPanel && (
+            <form
+              onSubmit={handleStartBot}
+              className="mt-4 space-y-3 animate-[fadeIn_0.2s_ease-in]"
+              style={{ animation: 'fadeIn 0.2s ease-in' }}
+            >
+              <style>{`@keyframes fadeIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }`}</style>
+              <div className="flex gap-3">
+                <div className="flex-1">
+                  <label className="block text-xs font-bold text-gray-600 mb-1">Difficulty</label>
+                  <select
+                    value={botDifficulty}
+                    onChange={(e) => setBotDifficulty(e.target.value as BotOptions['difficulty'])}
+                    className="w-full p-2 border border-gray-300 rounded-md text-sm"
+                  >
+                    <option value="easy">Easy</option>
+                    <option value="hard">Hard</option>
+                  </select>
+                </div>
+                <div className="flex-1">
+                  <label className="block text-xs font-bold text-gray-600 mb-1">Hand Size</label>
+                  <select
+                    value={botHandSize}
+                    onChange={(e) => setBotHandSize(parseInt(e.target.value))}
+                    className="w-full p-2 border border-gray-300 rounded-md text-sm"
+                  >
+                    <option value={5}>5 Cards</option>
+                    <option value={6}>6 Cards</option>
+                  </select>
+                </div>
+              </div>
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg shadow disabled:opacity-50 transition text-sm"
+              >
+                {isLoading ? 'Starting…' : 'Start Game'}
+              </button>
+            </form>
+          )}
+        </div>
 
         {/* Join by Code */}
         <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-200">

--- a/packages/client/src/components/PublicLobby.tsx
+++ b/packages/client/src/components/PublicLobby.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import type { RoomAvailable } from 'colyseus.js';
+import { useGame } from '../contexts/GameContext';
+import { useAuth } from '../contexts/AuthContext';
+
+export const PublicLobby: React.FC = () => {
+  const { findPublicGames, joinGame, createGame } = useGame();
+  const { user } = useAuth();
+
+  const [rooms, setRooms] = useState<RoomAvailable[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [joining, setJoining] = useState(false);
+
+  const fetchRooms = async () => {
+    try {
+      const available = await findPublicGames();
+      setRooms(available);
+    } catch (e) {
+      console.error('Failed to fetch public games', e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchRooms();
+    const interval = setInterval(() => void fetchRooms(), 5000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleJoin = async (roomId: string) => {
+    setJoining(true);
+    await joinGame(
+      roomId,
+      user?.method === 'discord' ? user.id : undefined,
+      user?.method === 'email' ? user.id : undefined,
+    );
+    setJoining(false);
+  };
+
+  const handleCreate = async () => {
+    setJoining(true);
+    await createGame({ isPublic: true, isPrivate: false, mode: 'classic' });
+    setJoining(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-indigo-950 text-white flex flex-col safe-p">
+      <header className="px-6 pt-8 pb-4 border-b border-indigo-800">
+        <h1 className="text-2xl font-extrabold tracking-tight">
+          ♦ Durak <span className="text-yellow-400">Online</span>
+        </h1>
+        <p className="text-indigo-300 text-sm mt-1">Find a public game or create one</p>
+      </header>
+
+      <main className="flex-1 flex flex-col px-4 py-6 gap-4 overflow-y-auto">
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-bold text-indigo-100">Public Games</h2>
+          <button
+            onClick={() => {
+              setLoading(true);
+              void fetchRooms();
+            }}
+            className="text-indigo-400 hover:text-indigo-200 text-sm transition"
+          >
+            ↻ Refresh
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex-1 flex items-center justify-center py-16">
+            <div className="w-10 h-10 border-4 border-indigo-400 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : rooms.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center py-16 gap-4 text-center">
+            <p className="text-indigo-300 text-base">No games found.</p>
+            <p className="text-indigo-400 text-sm">Create one and let others join!</p>
+            <button
+              onClick={handleCreate}
+              disabled={joining}
+              className="mt-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white font-bold py-3 px-8 rounded-xl shadow-lg transition"
+            >
+              {joining ? 'Creating…' : 'Create Public Game'}
+            </button>
+          </div>
+        ) : (
+          <>
+            <ul className="flex flex-col gap-3">
+              {rooms.map((r) => {
+                const meta = r.metadata as Record<string, unknown> | null;
+                const playerCount = (meta?.playerCount as number) ?? r.clients;
+                const maxPlayers = (meta?.maxPlayers as number) ?? r.maxClients;
+                const isFull = playerCount >= maxPlayers;
+                const gameMode = (meta?.mode as string) === 'teams' ? 'Teams' : 'Classic';
+                return (
+                  <li
+                    key={r.roomId}
+                    className="bg-indigo-900/60 border border-indigo-700 rounded-xl p-4 flex justify-between items-center"
+                  >
+                    <div>
+                      <div className="font-bold text-white">Room {r.roomId.substring(0, 6)}…</div>
+                      <div className="text-sm text-indigo-300 mt-0.5">
+                        {gameMode} · {playerCount}/{maxPlayers} players
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleJoin(r.roomId)}
+                      disabled={joining || isFull}
+                      className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white font-bold py-2 px-5 rounded-lg text-sm transition"
+                    >
+                      {isFull ? 'Full' : 'Join'}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <button
+              onClick={handleCreate}
+              disabled={joining}
+              className="mt-2 w-full bg-indigo-700/50 hover:bg-indigo-700 border border-indigo-600 disabled:opacity-50 text-white font-bold py-3 px-4 rounded-xl transition"
+            >
+              {joining ? 'Creating…' : '+ Create Public Game'}
+            </button>
+          </>
+        )}
+      </main>
+    </div>
+  );
+};

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -25,6 +25,11 @@ const RECONNECT_TOKEN_KEY = 'durak_reconnection_token';
 const MAX_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_DELAYS = [500, 2000, 4000]; // ms per attempt
 
+export interface BotOptions {
+  difficulty?: 'easy' | 'hard';
+  handSize?: number;
+}
+
 interface GameContextState {
   client: Client | null;
   room: Room<GameState> | null;
@@ -47,6 +52,7 @@ interface GameContextState {
   joinGame: (roomId: string, discordId?: string, userId?: string) => Promise<void>;
   spectateGame: (roomId: string) => Promise<void>;
   findPublicGames: () => Promise<RoomAvailable[]>;
+  playVsBot: (discordId?: string, userId?: string, opts?: BotOptions) => Promise<void>;
   leaveGame: () => void;
   autoJoinDiscordRoom: (
     instanceId: string,
@@ -81,6 +87,7 @@ const GameContext = createContext<GameContextState>({
   joinGame: async () => {},
   spectateGame: async () => {},
   findPublicGames: async () => [],
+  playVsBot: async () => {},
   leaveGame: () => {},
   autoJoinDiscordRoom: async () => {},
   updateLobbySettings: () => {},
@@ -347,6 +354,27 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return await client.getAvailableRooms('durak');
   };
 
+  const playVsBot = async (discordId?: string, userId?: string, opts?: BotOptions) => {
+    try {
+      const handSize = opts?.handSize ?? 5;
+      const difficulty = opts?.difficulty ?? 'easy';
+      const roomInstance = await client.create<GameState>('durak', {
+        maxPlayers: 2,
+        isPrivate: true,
+        mode: 'classic',
+        handSize,
+        ...(discordId ? { discordId } : {}),
+        ...(userId ? { userId } : {}),
+      });
+      handleRoomEvents(roomInstance);
+      // Spawn bot once the room is ready
+      roomInstance.send('dev_action', { action: 'spawn_dummies', difficulty });
+    } catch (e: unknown) {
+      console.error('Error starting bot game:', e);
+      setError(e instanceof Error ? e.message : 'Failed to start bot game');
+    }
+  };
+
   const autoJoinDiscordRoom = async (
     discordInstanceId: string,
     username: string,
@@ -425,6 +453,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         joinGame,
         spectateGame,
         findPublicGames,
+        playVsBot,
         leaveGame,
         autoJoinDiscordRoom,
         updateLobbySettings,


### PR DESCRIPTION
## Summary

Week 1.3 of the mobile release plan — mobile players now have a real entry point into games without Discord.

### PublicLobby (mobile home screen)
- Polls `GET /matchmake/durak` every 5s for joinable public rooms
- Each room shows mode, player count, Join button (disabled when full)
- Empty state: "No games found — Create one!" CTA
- Native users see this as their home screen after login

### Play vs Bot improvements
- Clicking "Play vs Bot" now expands an inline settings panel
- Difficulty: Easy / Hard
- Hand size: 5 / 6 cards
- Settings passed through to `spawn_dummies` dev action

## Test plan

- [ ] `npx tsc -p packages/client/tsconfig.json --noEmit` — 0 errors
- [ ] Open app on iOS simulator after auth → PublicLobby renders
- [ ] Create a public game → appears in list within 5s on another device
- [ ] Play vs Bot → settings panel expands → game starts with chosen difficulty

🤖 Generated with [Claude Code](https://claude.com/claude-code)