### PR TITLE
feat(deploy): production Docker build + Fly.io hardening + Capacitor Preferences

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,21 +5,29 @@ primary_region = "iad"
   kill_timeout = "35s"
 
 [build]
-  dockerfile = "Dockerfile"
+  dockerfile = "packages/server/Dockerfile"
 
 [env]
   PORT = "2567"
+  NODE_ENV = "production"
 
 [http_service]
   internal_port = 2567
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
   sticky_sessions = true
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/health"
 
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024

--- a/packages/client/capacitor.config.ts
+++ b/packages/client/capacitor.config.ts
@@ -4,6 +4,17 @@ const config: CapacitorConfig = {
   appId: 'com.durak.online',
   appName: 'Durak Online',
   webDir: 'dist',
+  plugins: {
+    SplashScreen: {
+      launchShowDuration: 2000,
+      backgroundColor: '#1e1b4b',
+      showSpinner: false,
+    },
+    StatusBar: {
+      style: 'dark',
+      backgroundColor: '#1e1b4b',
+    },
+  },
 };
 
 export default config;

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState, useMemo, useRef 
 import { Client, Room } from 'colyseus.js';
 import type { RoomAvailable } from 'colyseus.js';
 import { GameState } from '@durak/shared';
+import { storage } from '../utils/storage';
 
 type DefenseSnapshot = {
   at: number;
@@ -158,7 +159,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const attemptReconnect = async () => {
-    const token = sessionStorage.getItem(RECONNECT_TOKEN_KEY);
+    const token = await storage.get(RECONNECT_TOKEN_KEY);
     if (!token) return false;
 
     setIsReconnecting(true);
@@ -177,7 +178,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
 
     // All attempts exhausted
-    sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
+    await storage.remove(RECONNECT_TOKEN_KEY);
     setIsReconnecting(false);
     setConnectionStatus('connected');
     return false;
@@ -186,7 +187,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const handleRoomEvents = (roomInstance: Room<GameState>) => {
     // Persist token so the client can reconnect after a network drop or page refresh
     if (roomInstance.reconnectionToken) {
-      sessionStorage.setItem(RECONNECT_TOKEN_KEY, roomInstance.reconnectionToken);
+      void storage.set(RECONNECT_TOKEN_KEY, roomInstance.reconnectionToken);
     }
 
     roomInstance.onStateChange(() => setTick((t) => t + 1));
@@ -272,7 +273,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
             : `🎉 Game Over! ${data.loser} is the Durak.`,
         );
       // Game is over — no reconnection needed after this point
-      sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
+      void storage.remove(RECONNECT_TOKEN_KEY);
     });
     roomInstance.onMessage('turnExpired', (data: { playerId: string }) => {
       setGameMessage(
@@ -308,7 +309,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         if (reconnected) return;
       }
 
-      sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
+      await storage.remove(RECONNECT_TOKEN_KEY);
     });
     setRoom(roomInstance);
     setIsConnected(true);
@@ -397,7 +398,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const leaveGame = () => {
     if (room) {
-      sessionStorage.removeItem(RECONNECT_TOKEN_KEY);
+      void storage.remove(RECONNECT_TOKEN_KEY);
       setIsSpectator(false);
       room.leave();
     }
@@ -417,9 +418,9 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // On mount: if there's a saved reconnection token (e.g. after a page refresh), restore session
   useEffect(() => {
-    if (sessionStorage.getItem(RECONNECT_TOKEN_KEY)) {
-      attemptReconnect();
-    }
+    void storage.get(RECONNECT_TOKEN_KEY).then((token) => {
+      if (token) attemptReconnect();
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,27 +1,38 @@
-FROM node:20-alpine
+FROM node:22-alpine AS builder
 
 WORKDIR /usr/src/app
 
-# Copy root package.json and lockfile
+# Install dependencies first (layer caching)
 COPY package*.json ./
-
-# Copy packages package.json files so npm ci can resolve all workspaces
 COPY packages/server/package.json ./packages/server/
 COPY packages/client/package.json ./packages/client/
 COPY packages/shared/package.json ./packages/shared/
-
-# Install all workspace dependencies, including client build tooling
 RUN npm ci
 
-# Copy the rest of the monorepo code
+# Copy source and build everything
 COPY . .
-
-# Build the client so the server can serve the production UI from /packages/client/dist
 RUN npm run build:client
+RUN cd packages/server && npx tsc --noEmit false --outDir dist
 
-# Expose colyseus port
+# ── Production image ──────────────────────────────────────────────────────────
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+
+# Only production deps
+COPY package*.json ./
+COPY packages/server/package.json ./packages/server/
+COPY packages/client/package.json ./packages/client/
+COPY packages/shared/package.json ./packages/shared/
+RUN npm ci --omit=dev
+
+# Copy compiled server, built client, and shared source (needed at runtime for @durak/shared)
+COPY --from=builder /usr/src/app/packages/server/dist ./packages/server/dist
+COPY --from=builder /usr/src/app/packages/client/dist ./packages/client/dist
+COPY --from=builder /usr/src/app/packages/shared ./packages/shared
+
 EXPOSE 2567
 
 WORKDIR /usr/src/app/packages/server
 
-CMD ["npm", "start"]
+CMD ["node", "dist/index.js"]

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.ts",
   "scripts": {
     "start": "ts-node index.ts",
-    "start:prod": "ts-node --transpile-only index.ts",
+    "build": "tsc",
+    "start:prod": "node dist/index.js",
     "dev": "nodemon index.ts",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary

Week 1.1 + 2.4 of the mobile release plan — production server and native storage.

### Docker (server)
- **Multi-stage build**: `builder` stage compiles TypeScript, `prod` stage runs compiled JS — no `ts-node` in production
- Server `start:prod` now runs `node dist/index.js` (vs. ts-node)
- Node upgraded to 22-alpine

### Fly.io
- `min_machines_running = 1` — eliminates cold starts for mobile clients
- Memory bumped to 1 GB (Colyseus + Redis can be hungry)
- `/health` check added (15s interval, 5s timeout)
- Dockerfile path fixed to `packages/server/Dockerfile`

### Capacitor Preferences (storage)
- **GameContext**: reconnection token migrated from `sessionStorage` to `storage.ts` — persists across app kills on native
- **capacitor.config.ts**: SplashScreen (2s, dark purple `#1e1b4b`) and StatusBar configured

## Test plan

- [ ] `docker build -f packages/server/Dockerfile .` — builds cleanly
- [ ] `fly deploy` — deploys and passes `/health` check
- [ ] Kill app mid-game on iOS → reopen → reconnection restores session
- [ ] Splash screen shows on cold launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)