### PR TITLE
feat(mobile): app icon/splash placeholder + asset generation pipeline

### DIFF
--- a/packages/client/capacitor.config.ts
+++ b/packages/client/capacitor.config.ts
@@ -4,6 +4,10 @@ const config: CapacitorConfig = {
   appId: 'com.durak.online',
   appName: 'Durak Online',
   webDir: 'dist',
+  assets: {
+    iconPath: 'resources/icon.png',
+    splashPath: 'resources/splash.png',
+  },
   plugins: {
     SplashScreen: {
       launchShowDuration: 2000,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "gen:assets": "node scripts/generate-placeholder-icon.js && node scripts/generate-splash.js && npx @capacitor/assets generate"
   },
   "dependencies": {
     "@capacitor/android": "^8.3.1",

--- a/packages/client/resources/README.md
+++ b/packages/client/resources/README.md
@@ -1,0 +1,39 @@
+# App Assets
+
+This directory contains source assets for generating all required icon and splash screen sizes
+for iOS and Android via `@capacitor/assets`.
+
+## Required Files
+
+| File         | Size         | Description                                                               |
+| ------------ | ------------ | ------------------------------------------------------------------------- |
+| `icon.png`   | 1024x1024 px | App icon — dark purple background (#1e1b4b) with white spade/crown symbol |
+| `splash.png` | 2732x2732 px | Splash screen — same dark purple background, centered logo                |
+
+> **Note:** An `icon.svg` placeholder is included. To generate a proper `icon.png`, run:
+>
+> ```bash
+> npm run gen:assets
+> ```
+>
+> The script at `scripts/generate-placeholder-icon.js` will produce the SVG (no external deps).
+> For a production-quality PNG, open `icon.svg` in Figma / Inkscape and export at 1024x1024.
+
+## Auto-generating All Platform Sizes
+
+Once `icon.png` and `splash.png` exist, run:
+
+```bash
+npx @capacitor/assets generate
+```
+
+This generates every required size for iOS (`ios/App/App/Assets.xcassets/...`) and Android
+(`android/app/src/main/res/...`) from the two source files.
+
+## Design Spec
+
+- **Background:** `#1e1b4b` (Tailwind `indigo-950`)
+- **Symbol:** White spade (♠) or crown, centered, ~60% of canvas width
+- **Safe zone:** Keep the symbol within the inner 80% of the canvas so nothing is clipped on
+  round icon masks.
+- **Splash background:** Same `#1e1b4b`; the logo/symbol should be centered on a 2732x2732 canvas.

--- a/packages/client/resources/icon.svg
+++ b/packages/client/resources/icon.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1024" height="1024"
+     viewBox="0 0 1024 1024">
+  <!-- Background -->
+  <rect width="1024" height="1024" fill="#1e1b4b" rx="122.88" ry="122.88"/>
+
+  <!-- Spade symbol, scaled to ~60% of the canvas and centred -->
+  <!-- viewBox of the path above is 0 0 100 100; we place it in a 614x614 box offset by 205,185 -->
+  <g transform="translate(205, 185) scale(6.14)">
+    <path d="M50 5 C50 5 10 30 10 55 C10 72 25 82 38 78 C33 88 28 92 20 95 L80 95 C72 92 67 88 62 78 C75 82 90 72 90 55 C90 30 50 5 50 5 Z" fill="#ffffff"/>
+  </g>
+
+  <!-- "DURAK" wordmark below the spade -->
+  <text
+    x="512"
+    y="944"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="90"
+    font-weight="bold"
+    fill="#ffffff"
+    text-anchor="middle"
+    letter-spacing="12"
+    opacity="0.92">DURAK</text>
+</svg>

--- a/packages/client/scripts/generate-placeholder-icon.js
+++ b/packages/client/scripts/generate-placeholder-icon.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * generate-placeholder-icon.js
+ *
+ * Creates a placeholder app icon for the Durak card game.
+ *
+ * - If the `canvas` npm package is available it writes a 1024x1024 PNG to
+ *   packages/client/resources/icon.png
+ * - Otherwise it writes an SVG to packages/client/resources/icon.svg with an
+ *   identical design so it can be opened and exported manually.
+ *
+ * Design: dark purple background (#1e1b4b), white spade symbol centred.
+ */
+
+import { createRequire } from 'module';
+import { writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const RESOURCES_DIR = resolve(__dirname, '../resources');
+const BG_COLOR = '#1e1b4b';
+const FG_COLOR = '#ffffff';
+const SIZE = 1024;
+
+// Spade path — centered on a 100x100 viewBox, will be scaled to SIZE.
+// The spade body is a classic card-suit spade shape.
+const SPADE_PATH =
+  'M50 5 ' +
+  'C50 5 10 30 10 55 ' +
+  'C10 72 25 82 38 78 ' +
+  'C33 88 28 92 20 95 ' +
+  'L80 95 ' +
+  'C72 92 67 88 62 78 ' +
+  'C75 82 90 72 90 55 ' +
+  'C90 30 50 5 50 5 Z';
+
+// SVG string (used both as the file output and as the canvas source fallback)
+const svgContent = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="${SIZE}" height="${SIZE}"
+     viewBox="0 0 ${SIZE} ${SIZE}">
+  <!-- Background -->
+  <rect width="${SIZE}" height="${SIZE}" fill="${BG_COLOR}" rx="${SIZE * 0.12}" ry="${SIZE * 0.12}"/>
+
+  <!-- Spade symbol, scaled to ~60% of the canvas and centred -->
+  <!-- viewBox of the path above is 0 0 100 100; we place it in a 614x614 box offset by 205,185 -->
+  <g transform="translate(205, 185) scale(6.14)">
+    <path d="${SPADE_PATH}" fill="${FG_COLOR}"/>
+  </g>
+
+  <!-- "DURAK" wordmark below the spade -->
+  <text
+    x="${SIZE / 2}"
+    y="${SIZE - 80}"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="90"
+    font-weight="bold"
+    fill="${FG_COLOR}"
+    text-anchor="middle"
+    letter-spacing="12"
+    opacity="0.92">DURAK</text>
+</svg>
+`;
+
+mkdirSync(RESOURCES_DIR, { recursive: true });
+
+// Try to use canvas for a proper PNG output
+let canvasAvailable = false;
+try {
+  const require = createRequire(import.meta.url);
+  const { createCanvas } = require('canvas');
+  canvasAvailable = true;
+
+  const canvas = createCanvas(SIZE, SIZE);
+  const ctx = canvas.getContext('2d');
+
+  // Background with rounded corners
+  const radius = SIZE * 0.12;
+  ctx.fillStyle = BG_COLOR;
+  ctx.beginPath();
+  ctx.moveTo(radius, 0);
+  ctx.lineTo(SIZE - radius, 0);
+  ctx.quadraticCurveTo(SIZE, 0, SIZE, radius);
+  ctx.lineTo(SIZE, SIZE - radius);
+  ctx.quadraticCurveTo(SIZE, SIZE, SIZE - radius, SIZE);
+  ctx.lineTo(radius, SIZE);
+  ctx.quadraticCurveTo(0, SIZE, 0, SIZE - radius);
+  ctx.lineTo(0, radius);
+  ctx.quadraticCurveTo(0, 0, radius, 0);
+  ctx.closePath();
+  ctx.fill();
+
+  // Scale + translate to center the spade path (100x100 viewBox -> 614px, offset 205,185)
+  ctx.save();
+  ctx.translate(205, 185);
+  ctx.scale(6.14, 6.14);
+  ctx.fillStyle = FG_COLOR;
+  const p = new Path2D(SPADE_PATH);
+  ctx.fill(p);
+  ctx.restore();
+
+  // Wordmark
+  ctx.fillStyle = FG_COLOR;
+  ctx.font = `bold 90px Georgia, serif`;
+  ctx.textAlign = 'center';
+  ctx.globalAlpha = 0.92;
+  ctx.letterSpacing = '12px';
+  ctx.fillText('DURAK', SIZE / 2, SIZE - 80);
+  ctx.globalAlpha = 1;
+
+  const pngOut = resolve(RESOURCES_DIR, 'icon.png');
+  writeFileSync(pngOut, canvas.toBuffer('image/png'));
+  console.log(`✓ Written PNG icon: ${pngOut}`);
+} catch {
+  canvasAvailable = false;
+}
+
+if (!canvasAvailable) {
+  // Fallback: write SVG only
+  const svgOut = resolve(RESOURCES_DIR, 'icon.svg');
+  writeFileSync(svgOut, svgContent, 'utf8');
+  console.log(`✓ Written SVG icon (canvas not available): ${svgOut}`);
+  console.log('');
+  console.log('To convert to PNG for @capacitor/assets:');
+  console.log('  Option A: Open icon.svg in Figma / Inkscape and export at 1024x1024 PNG');
+  console.log('  Option B: Install canvas and re-run:');
+  console.log('    npm install canvas --save-dev');
+  console.log('    node scripts/generate-placeholder-icon.js');
+  console.log('  Option C: Use Inkscape CLI:');
+  console.log('    inkscape icon.svg --export-png=icon.png -w 1024 -h 1024');
+}

--- a/packages/client/scripts/generate-splash.js
+++ b/packages/client/scripts/generate-splash.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * generate-splash.js
+ *
+ * Documents how to create the 2732x2732 splash screen PNG required by
+ * @capacitor/assets for iOS and Android.
+ *
+ * This script cannot generate the final PNG automatically without a design
+ * tool or heavy native dependency (canvas + image compositing), so it prints
+ * clear instructions and writes a reference SVG that can be used as a starting
+ * point in Figma, Inkscape, or any SVG-capable editor.
+ *
+ * DESIGN SPEC
+ * -----------
+ * Canvas:     2732 x 2732 px
+ * Background: #1e1b4b  (Tailwind indigo-950)
+ * Logo:       White spade (♠) — 1200px wide, centred
+ * Wordmark:   "DURAK" in serif bold, white, ~160px, centred below spade
+ * Safe zone:  Keep all content within the inner 50% (1366x1366) so nothing
+ *             is clipped when the OS crops the splash on different device sizes.
+ *
+ * STEPS TO PRODUCE splash.png
+ * ---------------------------
+ * 1. Open splash.svg (written by this script) in Figma or Inkscape.
+ * 2. Export at 2732 x 2732 as PNG.
+ * 3. Save to packages/client/resources/splash.png.
+ * 4. Run: npx @capacitor/assets generate
+ *
+ * ALTERNATIVE (Inkscape CLI):
+ *   inkscape splash.svg --export-png=splash.png -w 2732 -h 2732
+ *
+ * ALTERNATIVE (ImageMagick):
+ *   convert -size 2732x2732 xc:'#1e1b4b' \
+ *     -gravity center -fill white -font Georgia-Bold \
+ *     -pointsize 400 -annotate 0 '♠' \
+ *     -pointsize 160 -annotate +0+700 'DURAK' \
+ *     splash.png
+ */
+
+import { writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const RESOURCES_DIR = resolve(__dirname, '../resources');
+const SIZE = 2732;
+const BG = '#1e1b4b';
+const FG = '#ffffff';
+
+// Spade path on a 100x100 viewBox (same as the icon script)
+const SPADE_PATH =
+  'M50 5 ' +
+  'C50 5 10 30 10 55 ' +
+  'C10 72 25 82 38 78 ' +
+  'C33 88 28 92 20 95 ' +
+  'L80 95 ' +
+  'C72 92 67 88 62 78 ' +
+  'C75 82 90 72 90 55 ' +
+  'C90 30 50 5 50 5 Z';
+
+// Scale the 100x100 path to 1200px width (scale=12), centred on 2732x2732
+// Centred X offset: (2732 - 1200) / 2 = 766
+// Centred Y offset: (2732 / 2) - 900 = 466  (place spade in the upper-centre half)
+const SPADE_SCALE = 12;
+const SPADE_OFFSET_X = (SIZE - 100 * SPADE_SCALE) / 2; // 766
+const SPADE_OFFSET_Y = SIZE / 2 - 900; // 466
+
+const svgContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Durak splash screen — 2732x2732 reference SVG.
+  Export this file to PNG at 2732x2732 and save as resources/splash.png.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="${SIZE}" height="${SIZE}"
+     viewBox="0 0 ${SIZE} ${SIZE}">
+
+  <!-- Background -->
+  <rect width="${SIZE}" height="${SIZE}" fill="${BG}"/>
+
+  <!-- Spade symbol (~1200px wide, centred horizontally, upper-centre vertically) -->
+  <g transform="translate(${SPADE_OFFSET_X}, ${SPADE_OFFSET_Y}) scale(${SPADE_SCALE})">
+    <path d="${SPADE_PATH}" fill="${FG}"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text
+    x="${SIZE / 2}"
+    y="${SIZE / 2 + 600}"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="200"
+    font-weight="bold"
+    fill="${FG}"
+    text-anchor="middle"
+    letter-spacing="30"
+    opacity="0.92">DURAK</text>
+
+  <!-- Safe-zone guide (remove before export) -->
+  <!--
+  <rect
+    x="${SIZE * 0.25}" y="${SIZE * 0.25}"
+    width="${SIZE * 0.5}" height="${SIZE * 0.5}"
+    fill="none" stroke="red" stroke-width="4" stroke-dasharray="20,20" opacity="0.3"/>
+  -->
+</svg>
+`;
+
+mkdirSync(RESOURCES_DIR, { recursive: true });
+
+const svgOut = resolve(RESOURCES_DIR, 'splash.svg');
+writeFileSync(svgOut, svgContent, 'utf8');
+console.log(`✓ Written splash reference SVG: ${svgOut}`);
+console.log('');
+console.log('Next steps:');
+console.log('  1. Export splash.svg at 2732x2732 PNG → resources/splash.png');
+console.log('  2. Run: npx @capacitor/assets generate');
+console.log('');
+console.log('Inkscape one-liner:');
+console.log('  inkscape resources/splash.svg --export-png=resources/splash.png -w 2732 -h 2732');


### PR DESCRIPTION
## Summary

Week 2.3 of the mobile release plan — asset generation pipeline scaffolded.

### What's in
- **`resources/icon.svg`**: dark purple `#1e1b4b` background, white ♠ spade + "DURAK" wordmark (replace with final design)
- **`resources/README.md`**: documents required source files and generation steps
- **`scripts/generate-placeholder-icon.js`**: generates `icon.png` via `canvas` if available, falls back to SVG
- **`scripts/generate-splash.js`**: generates 2732×2732 `splash.svg` reference with export instructions
- **`gen:assets` npm script**: runs generators then `npx @capacitor/assets generate` to produce all iOS/Android sizes
- **`capacitor.config.ts`**: `assets.iconPath` and `assets.splashPath` wired

### Before store submission (manual)
1. Export `resources/icon.svg` → `resources/icon.png` at 1024×1024
2. Run `node scripts/generate-splash.js` → export `splash.svg` → `splash.png` at 2732×2732
3. `npm run gen:assets -w @durak/client` — generates all required sizes

## Test plan

- [ ] `npm run gen:assets -w @durak/client` (after placing PNGs) — produces iOS/Android icon sets
- [ ] `npx cap open ios` → Xcode shows correct app icon in simulator
- [ ] Splash screen appears on cold launch (2s, dark purple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)