### PR TITLE
fix(#188,#192): helmet security headers + Dockerfile build ARG for Discord client ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN npm ci
 COPY . .
 
 # Build frontend assets that server will serve from packages/client/dist
-ENV VITE_DISCORD_CLIENT_ID=1493531312206647406
+# Pass via: docker build --build-arg VITE_DISCORD_CLIENT_ID=<id> .
+ARG VITE_DISCORD_CLIENT_ID
+ENV VITE_DISCORD_CLIENT_ID=$VITE_DISCORD_CLIENT_ID
 RUN npm run build:client
 
 ENV NODE_ENV=production

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,13 @@ primary_region = "iad"
 [build]
   dockerfile = "packages/server/Dockerfile"
 
+  # Pass the Discord Application ID as a build-time arg (not baked into the image).
+  # Set via: fly secrets set VITE_DISCORD_CLIENT_ID=<your-app-id>
+  # then:    fly deploy --build-arg VITE_DISCORD_CLIENT_ID=$(fly secrets list | grep DISCORD | ...)
+  # Or add to [build.args] below after running: fly deploy --build-secret VITE_DISCORD_CLIENT_ID
+  [build.args]
+    VITE_DISCORD_CLIENT_ID = ""
+
 [env]
   PORT = "2567"
   NODE_ENV = "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6000,6 +6000,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
@@ -10227,6 +10239,7 @@
         "@capacitor/core": "^8.3.1",
         "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.3.1",
+        "@capacitor/preferences": "^8.0.0",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
         "@discord/embedded-app-sdk": "^1.2.0",
@@ -10290,6 +10303,7 @@
         "cors": "^2.8.5",
         "dotenv": "^8.6.0",
         "express": "^4.19.0",
+        "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.6.0",
         "openai": "^6.37.0",

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -11,6 +11,10 @@ RUN npm ci
 
 # Copy source and build everything
 COPY . .
+# Pass via: fly deploy --build-arg VITE_DISCORD_CLIENT_ID=<id>
+# or in fly.toml [build.args] section
+ARG VITE_DISCORD_CLIENT_ID
+ENV VITE_DISCORD_CLIENT_ID=$VITE_DISCORD_CLIENT_ID
 RUN npm run build:client
 RUN cd packages/server && npx tsc --noEmit false --outDir dist
 

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -4,6 +4,7 @@ import { RedisDriver } from '@colyseus/redis-driver';
 import express from 'express';
 import http from 'http';
 import cors from 'cors';
+import helmet from 'helmet';
 import { monitor } from '@colyseus/monitor';
 import path from 'path';
 import fs from 'fs';
@@ -105,15 +106,23 @@ if (process.env.MONGO_URI) {
 
 const app = express();
 app.set('trust proxy', 1);
-app.use(cors());
-app.use(express.json());
 
-// Issue #69: Allow Discord to embed this application in an iframe
+// Issue #188: security headers — helmet baseline, then override for Discord embedding
+app.use(
+  helmet({
+    contentSecurityPolicy: false, // overridden below to allow Discord iframe
+    crossOriginEmbedderPolicy: false, // Discord Activity requires this off
+  }),
+);
 app.use((req, res, next) => {
   res.setHeader('Content-Security-Policy', 'frame-ancestors *');
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'ALLOWALL'); // allow Discord iframe
   next();
 });
+
+app.use(cors());
+app.use(express.json());
 
 // ── Discord token exchange (Embedded App SDK) ────────────────────────────────
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,6 +21,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.6.0",
     "express": "^4.19.0",
+    "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.6.0",
     "openai": "^6.37.0",


### PR DESCRIPTION
## Summary

Closes #188 · Closes #192

- **Security headers (#188)**: Added `helmet` middleware to the Express app with the baseline headers suite. Disabled `contentSecurityPolicy` and `crossOriginEmbedderPolicy` at the helmet level (Discord Activity embedding requires `frame-ancestors *` and `SharedArrayBuffer`), then manually set `X-Content-Type-Options: nosniff` and `X-Frame-Options: ALLOWALL`
- **Dockerfile build ARG (#192)**: `VITE_DISCORD_CLIENT_ID` is now passed as a `--build-arg` instead of being hardcoded as `ENV` in both `Dockerfile` (root) and `packages/server/Dockerfile`. The `[build.args]` section in `fly.toml` documents where to set it for Fly deployments

## How to deploy

```bash
fly deploy --build-arg VITE_DISCORD_CLIENT_ID=1493531312206647406
```

Or set it in `fly.toml`:
```toml
[build.args]
  VITE_DISCORD_CLIENT_ID = "1493531312206647406"
```

## Test plan

- [ ] Verify `/health` response headers include `X-Content-Type-Options: nosniff`
- [ ] Verify `Content-Security-Policy: frame-ancestors *` still present (Discord embedding works)
- [ ] Build Docker image without `--build-arg` and confirm `VITE_DISCORD_CLIENT_ID` is empty (not leaked)
- [ ] Build with `--build-arg VITE_DISCORD_CLIENT_ID=<id>` and confirm client loads correctly in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)