### PR TITLE
feat(#199,#200,#201): friends + teams — data model, REST API, and Friends UI panel

### DIFF
--- a/packages/client/src/components/FriendsPanel.tsx
+++ b/packages/client/src/components/FriendsPanel.tsx
@@ -1,0 +1,393 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { storage } from '../utils/storage';
+
+interface Friend {
+  profileId: string;
+  username: string;
+  avatarUrl: string;
+  eloClassic: number;
+}
+
+interface PendingRequest {
+  friendshipId: string;
+  from: { profileId: string; username: string; avatarUrl: string };
+}
+
+interface SearchResult {
+  profileId: string;
+  username: string;
+  avatarUrl: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'friends' | 'pending' | 'add';
+
+const API = '/api';
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const raw = await storage.get('durak_auth');
+  const auth = JSON.parse(raw ?? '{}') as { token?: string };
+  return { Authorization: `Bearer ${auth.token ?? ''}`, 'Content-Type': 'application/json' };
+}
+
+const Avatar: React.FC<{ url: string; username: string }> = ({ url, username }) => (
+  <img
+    src={url}
+    alt={username}
+    className="w-8 h-8 rounded-full object-cover bg-indigo-800 shrink-0"
+    onError={(e) => {
+      (e.currentTarget as HTMLImageElement).src =
+        `https://ui-avatars.com/api/?name=${encodeURIComponent(username)}&background=4338ca&color=fff&size=32`;
+    }}
+  />
+);
+
+export const FriendsPanel: React.FC<Props> = ({ open, onClose }) => {
+  const [tab, setTab] = useState<Tab>('friends');
+  const [friends, setFriends] = useState<Friend[]>([]);
+  const [pending, setPending] = useState<PendingRequest[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [loadingFriends, setLoadingFriends] = useState(false);
+  const [loadingPending, setLoadingPending] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [actionIds, setActionIds] = useState<Set<string>>(new Set());
+  const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFriends = useCallback(async () => {
+    setLoadingFriends(true);
+    setError(null);
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/friends`, { headers });
+      if (!res.ok) throw new Error();
+      const data = (await res.json()) as Friend[];
+      setFriends(data);
+    } catch {
+      setError('Failed to load friends.');
+    } finally {
+      setLoadingFriends(false);
+    }
+  }, []);
+
+  const fetchPending = useCallback(async () => {
+    setLoadingPending(true);
+    setError(null);
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/friends/pending`, { headers });
+      if (!res.ok) throw new Error();
+      const data = (await res.json()) as PendingRequest[];
+      setPending(data);
+    } catch {
+      setError('Failed to load requests.');
+    } finally {
+      setLoadingPending(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    if (tab === 'friends') fetchFriends();
+    else if (tab === 'pending') fetchPending();
+  }, [open, tab, fetchFriends, fetchPending]);
+
+  const handleRemove = useCallback(async (profileId: string) => {
+    setActionIds((prev) => new Set(prev).add(profileId));
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/friends/${profileId}`, { method: 'DELETE', headers });
+      if (res.ok) setFriends((prev) => prev.filter((f) => f.profileId !== profileId));
+    } finally {
+      setActionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(profileId);
+        return next;
+      });
+    }
+  }, []);
+
+  const handleAccept = useCallback(async (friendshipId: string) => {
+    setActionIds((prev) => new Set(prev).add(friendshipId));
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/friends/accept`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ friendshipId }),
+      });
+      if (res.ok) setPending((prev) => prev.filter((p) => p.friendshipId !== friendshipId));
+    } finally {
+      setActionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(friendshipId);
+        return next;
+      });
+    }
+  }, []);
+
+  const handleReject = useCallback(async (friendshipId: string) => {
+    setActionIds((prev) => new Set(prev).add(friendshipId));
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/friends/reject`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ friendshipId }),
+      });
+      if (res.ok) setPending((prev) => prev.filter((p) => p.friendshipId !== friendshipId));
+    } finally {
+      setActionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(friendshipId);
+        return next;
+      });
+    }
+  }, []);
+
+  const handleSearch = useCallback(async () => {
+    if (!searchQuery.trim()) return;
+    setSearching(true);
+    setSearchResults([]);
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/profile/search?q=${encodeURIComponent(searchQuery.trim())}`, {
+        headers,
+      });
+      if (!res.ok) throw new Error();
+      const data = (await res.json()) as SearchResult[];
+      setSearchResults(data);
+    } catch {
+      setSearchResults([]);
+    } finally {
+      setSearching(false);
+    }
+  }, [searchQuery]);
+
+  const handleAddFriend = useCallback(async (targetProfileId: string) => {
+    setActionIds((prev) => new Set(prev).add(targetProfileId));
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${API}/friends/request`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ targetProfileId }),
+      });
+      if (res.ok) setAddedIds((prev) => new Set(prev).add(targetProfileId));
+    } finally {
+      setActionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(targetProfileId);
+        return next;
+      });
+    }
+  }, []);
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'friends', label: 'Friends' },
+    { key: 'pending', label: 'Pending' },
+    { key: 'add', label: 'Add Friend' },
+  ];
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            className="fixed inset-0 bg-black/40 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+          <motion.div
+            className="fixed right-0 top-0 h-full w-80 bg-indigo-950 border-l border-indigo-800 z-50 flex flex-col shadow-2xl"
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-indigo-800">
+              <span className="text-white font-bold text-base">Friends</span>
+              <button
+                onClick={onClose}
+                className="text-indigo-400 hover:text-white transition text-xl leading-none"
+              >
+                ×
+              </button>
+            </div>
+
+            <div className="flex border-b border-indigo-800">
+              {tabs.map(({ key, label }) => (
+                <button
+                  key={key}
+                  onClick={() => {
+                    setTab(key);
+                    setError(null);
+                  }}
+                  className={`flex-1 py-2 text-xs font-semibold transition ${
+                    tab === key
+                      ? 'text-white border-b-2 border-indigo-400'
+                      : 'text-indigo-400 hover:text-indigo-200'
+                  }`}
+                >
+                  {label}
+                  {key === 'pending' && pending.length > 0 && (
+                    <span className="ml-1 bg-indigo-500 text-white text-xs rounded-full px-1.5 py-0.5">
+                      {pending.length}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-3 space-y-2">
+              {error && <div className="text-red-400 text-xs text-center py-2">{error}</div>}
+
+              {tab === 'friends' && (
+                <>
+                  {loadingFriends ? (
+                    <div className="text-indigo-400 text-xs text-center py-6 animate-pulse">
+                      Loading…
+                    </div>
+                  ) : friends.length === 0 ? (
+                    <div className="text-indigo-400 text-xs text-center py-6">
+                      No friends yet — add some!
+                    </div>
+                  ) : (
+                    friends.map((f) => (
+                      <div
+                        key={f.profileId}
+                        className="flex items-center gap-3 bg-indigo-900/60 border border-indigo-800 rounded-lg px-3 py-2"
+                      >
+                        <Avatar url={f.avatarUrl} username={f.username} />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-white text-sm font-semibold truncate">
+                            {f.username}
+                          </div>
+                          <div className="text-indigo-400 text-xs">{f.eloClassic} ELO</div>
+                        </div>
+                        <button
+                          onClick={() => handleRemove(f.profileId)}
+                          disabled={actionIds.has(f.profileId)}
+                          className="text-xs text-red-400 hover:text-red-300 disabled:opacity-40 transition shrink-0"
+                        >
+                          {actionIds.has(f.profileId) ? '…' : 'Remove'}
+                        </button>
+                      </div>
+                    ))
+                  )}
+                </>
+              )}
+
+              {tab === 'pending' && (
+                <>
+                  {loadingPending ? (
+                    <div className="text-indigo-400 text-xs text-center py-6 animate-pulse">
+                      Loading…
+                    </div>
+                  ) : pending.length === 0 ? (
+                    <div className="text-indigo-400 text-xs text-center py-6">
+                      No pending requests.
+                    </div>
+                  ) : (
+                    pending.map((req) => (
+                      <div
+                        key={req.friendshipId}
+                        className="flex items-center gap-3 bg-indigo-900/60 border border-indigo-800 rounded-lg px-3 py-2"
+                      >
+                        <Avatar url={req.from.avatarUrl} username={req.from.username} />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-white text-sm font-semibold truncate">
+                            {req.from.username}
+                          </div>
+                        </div>
+                        <div className="flex gap-1 shrink-0">
+                          <button
+                            onClick={() => handleAccept(req.friendshipId)}
+                            disabled={actionIds.has(req.friendshipId)}
+                            className="text-xs bg-green-700 hover:bg-green-600 disabled:opacity-40 text-white px-2 py-1 rounded transition"
+                          >
+                            {actionIds.has(req.friendshipId) ? '…' : 'Accept'}
+                          </button>
+                          <button
+                            onClick={() => handleReject(req.friendshipId)}
+                            disabled={actionIds.has(req.friendshipId)}
+                            className="text-xs bg-indigo-700 hover:bg-indigo-600 disabled:opacity-40 text-white px-2 py-1 rounded transition"
+                          >
+                            Reject
+                          </button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </>
+              )}
+
+              {tab === 'add' && (
+                <div className="space-y-3">
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleSearch();
+                      }}
+                      placeholder="Search username…"
+                      className="flex-1 bg-indigo-900/60 border border-indigo-700 rounded-lg px-3 py-2 text-white text-sm placeholder-indigo-500 focus:outline-none focus:border-indigo-500"
+                    />
+                    <button
+                      onClick={handleSearch}
+                      disabled={searching || !searchQuery.trim()}
+                      className="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white text-xs px-3 py-2 rounded-lg font-semibold transition"
+                    >
+                      {searching ? '…' : 'Search'}
+                    </button>
+                  </div>
+
+                  {searchResults.map((result) => {
+                    const added = addedIds.has(result.profileId);
+                    const acting = actionIds.has(result.profileId);
+                    return (
+                      <div
+                        key={result.profileId}
+                        className="flex items-center gap-3 bg-indigo-900/60 border border-indigo-800 rounded-lg px-3 py-2"
+                      >
+                        <Avatar url={result.avatarUrl} username={result.username} />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-white text-sm font-semibold truncate">
+                            {result.username}
+                          </div>
+                        </div>
+                        {added ? (
+                          <span className="text-xs text-green-400 font-semibold shrink-0">
+                            Sent!
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() => handleAddFriend(result.profileId)}
+                            disabled={acting}
+                            className="text-xs bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white px-2 py-1 rounded transition shrink-0"
+                          >
+                            {acting ? '…' : 'Add'}
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -24,6 +24,8 @@ import { getTierInfo } from '@durak/shared';
 import { CoinTransaction } from './src/models/CoinTransaction';
 import { isSameUTCDay, COIN_REWARDS, awardCoins } from './src/utils/coins';
 import { iapRouter } from './src/routes/iap';
+import { friendsRouter } from './src/routes/friends';
+import { teamsRouter } from './src/routes/teams';
 
 if (process.env.SENTRY_DSN) {
   Sentry.init({ dsn: process.env.SENTRY_DSN });
@@ -273,6 +275,33 @@ app.get('/api/auth/me', async (req, res) => {
 
 // ── Profile & history API ────────────────────────────────────────────────────
 
+// GET /api/profile/search?q=username — fuzzy username search for friend/team invites
+app.get('/api/profile/search', async (req, res) => {
+  const q = String(req.query.q ?? '').trim();
+  if (!q || q.length < 2) {
+    res.status(400).json({ error: 'q must be at least 2 characters' });
+    return;
+  }
+  try {
+    const results = await PlayerProfile.find({
+      username: { $regex: q, $options: 'i' },
+    })
+      .limit(10)
+      .select('_id username avatarUrl eloClassic')
+      .lean();
+    res.json(
+      results.map((p) => ({
+        profileId: p._id.toString(),
+        username: p.username,
+        avatarUrl: p.avatarUrl,
+        eloClassic: p.eloClassic,
+      })),
+    );
+  } catch (e: unknown) {
+    res.status(500).json({ error: e instanceof Error ? e.message : 'Server error' });
+  }
+});
+
 // Accepts ?by=discord (default) or ?by=user
 app.get('/api/profile/:id', async (req, res) => {
   try {
@@ -452,6 +481,8 @@ gameServer.define('durak', DurakRoom).filterBy(['discordInstanceId']);
 
 app.use('/api/shop', shopRouter);
 app.use('/api/iap', iapRouter);
+app.use('/api/friends', friendsRouter);
+app.use('/api/teams', teamsRouter);
 app.use('/colyseus', monitor());
 
 const clientDistPath = path.resolve(__dirname, '../client/dist');

--- a/packages/server/src/models/Friendship.ts
+++ b/packages/server/src/models/Friendship.ts
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+export type FriendshipStatus = 'pending' | 'accepted' | 'rejected';
+
+export interface IFriendship extends mongoose.Document {
+  senderId: string;
+  receiverId: string;
+  status: FriendshipStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const FriendshipSchema = new mongoose.Schema(
+  {
+    senderId: { type: String, required: true, index: true },
+    receiverId: { type: String, required: true, index: true },
+    status: { type: String, enum: ['pending', 'accepted', 'rejected'], default: 'pending' },
+  },
+  { timestamps: true },
+);
+
+FriendshipSchema.index({ senderId: 1, receiverId: 1 }, { unique: true });
+
+export const Friendship = mongoose.model<IFriendship>('Friendship', FriendshipSchema);

--- a/packages/server/src/models/Team.ts
+++ b/packages/server/src/models/Team.ts
@@ -1,0 +1,73 @@
+import mongoose from 'mongoose';
+
+export type TeamMemberRole = 'owner' | 'member';
+export type TeamInviteStatus = 'pending' | 'accepted' | 'rejected';
+
+export interface ITeamMember {
+  profileId: string;
+  role: TeamMemberRole;
+  joinedAt: Date;
+}
+
+export interface ITeamInvite {
+  profileId: string;
+  status: TeamInviteStatus;
+  invitedAt: Date;
+}
+
+export interface ITeam extends mongoose.Document {
+  name: string;
+  tag: string; // short 2-5 char tag, e.g. "DRK"
+  ownerId: string;
+  members: ITeamMember[];
+  invites: ITeamInvite[];
+  eloTeams: number;
+  stats: {
+    gamesPlayed: number;
+    wins: number;
+    losses: number;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const TeamSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, unique: true, trim: true, maxlength: 32 },
+    tag: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      uppercase: true,
+      minlength: 2,
+      maxlength: 5,
+    },
+    ownerId: { type: String, required: true, index: true },
+    members: [
+      {
+        profileId: { type: String, required: true },
+        role: { type: String, enum: ['owner', 'member'], default: 'member' },
+        joinedAt: { type: Date, default: Date.now },
+      },
+    ],
+    invites: [
+      {
+        profileId: { type: String, required: true },
+        status: { type: String, enum: ['pending', 'accepted', 'rejected'], default: 'pending' },
+        invitedAt: { type: Date, default: Date.now },
+      },
+    ],
+    eloTeams: { type: Number, default: 1000 },
+    stats: {
+      gamesPlayed: { type: Number, default: 0 },
+      wins: { type: Number, default: 0 },
+      losses: { type: Number, default: 0 },
+    },
+  },
+  { timestamps: true },
+);
+
+TeamSchema.index({ eloTeams: -1 });
+
+export const Team = mongoose.model<ITeam>('Team', TeamSchema);

--- a/packages/server/src/routes/friends.ts
+++ b/packages/server/src/routes/friends.ts
@@ -1,0 +1,183 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { Friendship } from '../models/Friendship';
+import { PlayerProfile, type IPlayerProfile } from '../models/PlayerProfile';
+
+export const friendsRouter = Router();
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'durak-dev-secret-change-in-prod';
+
+interface AuthedRequest extends Request {
+  profile: IPlayerProfile;
+}
+
+async function requireProfile(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing token' });
+    return;
+  }
+  try {
+    const payload = jwt.verify(auth.slice(7), JWT_SECRET) as { userId: string };
+    const profile = await PlayerProfile.findOne({ userId: payload.userId });
+    if (!profile) {
+      res.status(401).json({ error: 'Profile not found' });
+      return;
+    }
+    (req as AuthedRequest).profile = profile;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+
+friendsRouter.use(
+  requireProfile as unknown as (req: Request, res: Response, next: NextFunction) => void,
+);
+
+friendsRouter.get('/', async (req: Request, res: Response) => {
+  const myId = (req as AuthedRequest).profile._id.toString();
+  const friendships = await Friendship.find({
+    $or: [{ senderId: myId }, { receiverId: myId }],
+    status: 'accepted',
+  }).lean();
+
+  const otherIds = friendships.map((f) => (f.senderId === myId ? f.receiverId : f.senderId));
+  const profiles = await PlayerProfile.find({ _id: { $in: otherIds } })
+    .select('username avatarUrl eloClassic')
+    .lean();
+
+  res.json(
+    profiles.map((p) => ({
+      profileId: p._id.toString(),
+      username: p.username,
+      avatarUrl: p.avatarUrl,
+      eloClassic: p.eloClassic,
+    })),
+  );
+});
+
+friendsRouter.get('/pending', async (req: Request, res: Response) => {
+  const myId = (req as AuthedRequest).profile._id.toString();
+  const pending = await Friendship.find({ receiverId: myId, status: 'pending' }).lean();
+
+  const senderIds = pending.map((f) => f.senderId);
+  const profiles = await PlayerProfile.find({ _id: { $in: senderIds } })
+    .select('username avatarUrl eloClassic')
+    .lean();
+
+  const profileMap = new Map(profiles.map((p) => [p._id.toString(), p]));
+
+  res.json(
+    pending.map((f) => {
+      const sender = profileMap.get(f.senderId);
+      return {
+        friendshipId: f._id.toString(),
+        profileId: f.senderId,
+        username: sender?.username ?? '',
+        avatarUrl: sender?.avatarUrl ?? '',
+        eloClassic: sender?.eloClassic ?? 1000,
+      };
+    }),
+  );
+});
+
+friendsRouter.post('/request', async (req: Request, res: Response) => {
+  const myId = (req as AuthedRequest).profile._id.toString();
+  const { targetProfileId } = req.body as { targetProfileId?: string };
+
+  if (!targetProfileId) {
+    res.status(400).json({ error: 'targetProfileId is required' });
+    return;
+  }
+  if (targetProfileId === myId) {
+    res.status(400).json({ error: 'Cannot send friend request to yourself' });
+    return;
+  }
+
+  const existing = await Friendship.findOne({
+    $or: [
+      { senderId: myId, receiverId: targetProfileId },
+      { senderId: targetProfileId, receiverId: myId },
+    ],
+  });
+
+  if (existing?.status === 'accepted') {
+    res.status(409).json({ error: 'Already friends' });
+    return;
+  }
+
+  const friendship = await Friendship.findOneAndUpdate(
+    { senderId: myId, receiverId: targetProfileId },
+    { status: 'pending' },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+
+  res.status(201).json({ friendshipId: friendship._id.toString(), status: friendship.status });
+});
+
+friendsRouter.post('/accept', async (req: Request, res: Response) => {
+  const myId = (req as AuthedRequest).profile._id.toString();
+  const { friendshipId } = req.body as { friendshipId?: string };
+
+  if (!friendshipId) {
+    res.status(400).json({ error: 'friendshipId is required' });
+    return;
+  }
+
+  const friendship = await Friendship.findOneAndUpdate(
+    { _id: friendshipId, receiverId: myId, status: 'pending' },
+    { status: 'accepted' },
+    { new: true },
+  );
+
+  if (!friendship) {
+    res.status(404).json({ error: 'Pending request not found' });
+    return;
+  }
+
+  res.json({ friendshipId: friendship._id.toString(), status: friendship.status });
+});
+
+friendsRouter.post('/reject', async (req: Request, res: Response) => {
+  const myId = (req as AuthedRequest).profile._id.toString();
+  const { friendshipId } = req.body as { friendshipId?: string };
+
+  if (!friendshipId) {
+    res.status(400).json({ error: 'friendshipId is required' });
+    return;
+  }
+
+  const friendship = await Friendship.findOneAndUpdate(
+    { _id: friendshipId, receiverId: myId, status: 'pending' },
+    { status: 'rejected' },
+    { new: true },
+  );
+
+  if (!friendship) {
+    res.status(404).json({ error: 'Pending request not found' });
+    return;
+  }
+
+  res.json({ friendshipId: friendship._id.toString(), status: friendship.status });
+});
+
+friendsRouter.delete('/:profileId', async (req: Request, res: Response) => {
+  const myId = (req as AuthedRequest).profile._id.toString();
+  const otherId = req.params.profileId;
+
+  const result = await Friendship.deleteOne({
+    $or: [
+      { senderId: myId, receiverId: otherId },
+      { senderId: otherId, receiverId: myId },
+    ],
+    status: 'accepted',
+  });
+
+  if (result.deletedCount === 0) {
+    res.status(404).json({ error: 'Friendship not found' });
+    return;
+  }
+
+  res.json({ ok: true });
+});

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -1,0 +1,182 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { PlayerProfile, IPlayerProfile } from '../models/PlayerProfile';
+import { Team } from '../models/Team';
+
+const router = Router();
+
+interface AuthRequest extends Request {
+  profile?: IPlayerProfile;
+}
+
+async function requireProfile(req: AuthRequest, res: Response, next: NextFunction) {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  try {
+    const payload = jwt.verify(header.slice(7), process.env.JWT_SECRET || '') as {
+      userId: string;
+    };
+    const profile = await PlayerProfile.findOne({ userId: payload.userId });
+    if (!profile) {
+      res.status(401).json({ error: 'Profile not found' });
+      return;
+    }
+    req.profile = profile;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+// POST /api/teams — create a new team
+router.post('/', requireProfile, async (req: AuthRequest, res: Response) => {
+  const { name, tag } = req.body as { name?: string; tag?: string };
+  if (!name || !tag) {
+    res.status(400).json({ error: 'name and tag are required' });
+    return;
+  }
+  const profileId = req.profile!._id.toString();
+  try {
+    const existing = await Team.findOne({ ownerId: profileId });
+    if (existing) {
+      res.status(409).json({ error: 'You already own a team' });
+      return;
+    }
+    const team = await Team.create({
+      name: name.trim(),
+      tag: tag.trim().toUpperCase(),
+      ownerId: profileId,
+      members: [{ profileId, role: 'owner', joinedAt: new Date() }],
+    });
+    res.status(201).json(team);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Failed to create team';
+    res.status(400).json({ error: msg });
+  }
+});
+
+// GET /api/teams/:id — get team details
+router.get('/:id', async (req: Request, res: Response) => {
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) {
+      res.status(404).json({ error: 'Team not found' });
+      return;
+    }
+    const memberIds = team.members.map((m) => m.profileId);
+    const profiles = await PlayerProfile.find({ _id: { $in: memberIds } }).select(
+      '_id username avatarUrl eloTeams',
+    );
+    const profileMap = new Map(profiles.map((p) => [p._id.toString(), p]));
+    const members = team.members.map((m) => ({
+      profileId: m.profileId,
+      role: m.role,
+      joinedAt: m.joinedAt,
+      profile: profileMap.get(m.profileId),
+    }));
+    res.json({ ...team.toObject(), members });
+  } catch {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// GET /api/teams — leaderboard (top 50 by eloTeams)
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const teams = await Team.find({ 'stats.gamesPlayed': { $gte: 1 } })
+      .sort({ eloTeams: -1 })
+      .limit(50)
+      .select('name tag ownerId eloTeams stats');
+    res.json(teams);
+  } catch {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// POST /api/teams/:id/invite — invite a player
+router.post('/:id/invite', requireProfile, async (req: AuthRequest, res: Response) => {
+  const { targetProfileId } = req.body as { targetProfileId?: string };
+  if (!targetProfileId) {
+    res.status(400).json({ error: 'targetProfileId required' });
+    return;
+  }
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) {
+      res.status(404).json({ error: 'Team not found' });
+      return;
+    }
+    if (team.ownerId !== req.profile!._id.toString()) {
+      res.status(403).json({ error: 'Only the team owner can invite' });
+      return;
+    }
+    const alreadyMember = team.members.some((m) => m.profileId === targetProfileId);
+    if (alreadyMember) {
+      res.status(409).json({ error: 'Already a member' });
+      return;
+    }
+    const existingInvite = team.invites.find(
+      (i) => i.profileId === targetProfileId && i.status === 'pending',
+    );
+    if (existingInvite) {
+      res.status(409).json({ error: 'Invite already pending' });
+      return;
+    }
+    team.invites.push({ profileId: targetProfileId, status: 'pending', invitedAt: new Date() });
+    await team.save();
+    res.json({ success: true });
+  } catch {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// POST /api/teams/:id/accept — accept an invite
+router.post('/:id/accept', requireProfile, async (req: AuthRequest, res: Response) => {
+  const profileId = req.profile!._id.toString();
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) {
+      res.status(404).json({ error: 'Team not found' });
+      return;
+    }
+    const invite = team.invites.find((i) => i.profileId === profileId && i.status === 'pending');
+    if (!invite) {
+      res.status(404).json({ error: 'No pending invite found' });
+      return;
+    }
+    invite.status = 'accepted';
+    team.members.push({ profileId, role: 'member', joinedAt: new Date() });
+    await team.save();
+    res.json({ success: true });
+  } catch {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// DELETE /api/teams/:id/leave — leave or disband team
+router.delete('/:id/leave', requireProfile, async (req: AuthRequest, res: Response) => {
+  const profileId = req.profile!._id.toString();
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) {
+      res.status(404).json({ error: 'Team not found' });
+      return;
+    }
+    if (team.ownerId === profileId) {
+      // Owner disbands the team
+      await Team.deleteOne({ _id: team._id });
+      res.json({ disbanded: true });
+      return;
+    }
+    team.members = team.members.filter((m) => m.profileId !== profileId);
+    await team.save();
+    res.json({ success: true });
+  } catch {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+export { router as teamsRouter };


### PR DESCRIPTION
## Summary

Closes #199 · Closes #200 · Closes #201

### Friends system (#201 — data model & API)
- **`Friendship` model** — `senderId`, `receiverId`, `status` (pending/accepted/rejected), unique compound index prevents duplicate requests
- **`/api/friends` router** — JWT-protected `requireProfile` middleware; six endpoints:
  - `GET /` — list accepted friends with profile details
  - `GET /pending` — incoming pending requests
  - `POST /request` — send request (upsert, 409 on already-accepted)
  - `POST /accept` / `POST /reject` — act on a received request
  - `DELETE /:profileId` — remove friendship from either direction

### Teams system (#200 — data model & API)
- **`Team` model** — name, tag (2-5 chars, unique), owner, `members[]`, `invites[]`, `eloTeams`, stats
- **`/api/teams` router**:
  - `POST /` — create team (one team per owner)
  - `GET /` — leaderboard (top 50 by eloTeams, ≥1 game)
  - `GET /:id` — team details with member profiles
  - `POST /:id/invite` — owner invites a player
  - `POST /:id/accept` — accept team invite
  - `DELETE /:id/leave` — leave (or disband if owner)

### Profile search (supporting endpoint)
- `GET /api/profile/search?q=` — case-insensitive username fuzzy search (limit 10), used by friend and team invite flows

### Friends UI panel (#199)
- `FriendsPanel.tsx` — slide-in Framer Motion panel with backdrop
- Three tabs: **Friends** (list + remove) | **Pending** (accept/reject with badge count) | **Add Friend** (search + request)
- Per-action loading state, Capacitor-aware auth via `storage.ts`

## Test plan

- [ ] `POST /api/friends/request` with valid JWT creates a pending Friendship doc
- [ ] `GET /api/friends/pending` returns the request from the other user's perspective
- [ ] Accept → friendship appears in `GET /api/friends` for both parties
- [ ] `DELETE /api/friends/:profileId` removes from both sides
- [ ] `POST /api/teams` creates team with owner as first member
- [ ] Second user can accept team invite and appear in `GET /api/teams/:id` members list
- [ ] Owner `DELETE /api/teams/:id/leave` disbands the team
- [ ] `GET /api/profile/search?q=al` returns profiles with "al" in username

🤖 Generated with [Claude Code](https://claude.com/claude-code)