### PR TITLE
fix: ELO and stats not updating — identity passing, upsert safety, push-based profile refresh

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -32,7 +32,6 @@ export const GameBoard: React.FC = () => {
     clearDiscardedCards,
     defenseRevealPairs,
     eloResult,
-    clearEloResult,
     rematchState,
     gameAbortReason,
     clearGameAbortReason,
@@ -43,10 +42,12 @@ export const GameBoard: React.FC = () => {
     isSpectator,
     connectionStatus,
     disconnectedOpponent,
+    leaveGame,
   } = useGame();
   const [selectedCards, setSelectedCards] = useState<SharedCard[]>([]);
   const [devSelectedCards, setDevSelectedCards] = useState<Record<string, SharedCard[]>>({});
   const [timeRemaining, setTimeRemaining] = useState<number>(0);
+  const [hasVotedRematch, setHasVotedRematch] = useState(false);
   const {
     playDealSound,
     playCardSound,
@@ -128,6 +129,11 @@ export const GameBoard: React.FC = () => {
       playVictorySound();
     }
   }, [gameState?.phase, gameState?.loser, room?.sessionId, playVictorySound, playDefeatSound]);
+
+  // Reset rematch vote when a new game starts so the button reappears
+  React.useEffect(() => {
+    if (gameState?.phase === 'playing') setHasVotedRematch(false);
+  }, [gameState?.phase]);
 
   // ── Drag-and-drop state (declared before early return to satisfy rules-of-hooks) ──
   const dropZoneRef = useRef<HTMLDivElement>(null);
@@ -266,10 +272,6 @@ export const GameBoard: React.FC = () => {
     } else {
       setSelectedCards([...selectedCards, card]);
     }
-  };
-
-  const handleStartGame = () => {
-    room.send('startGame');
   };
 
   const handleAttack = () => {
@@ -1274,223 +1276,7 @@ export const GameBoard: React.FC = () => {
         />
       )}
 
-      {/* ── ELO Result Overlay (ranked games only) ── */}
-      {eloResult &&
-        (() => {
-          const accent = eloResult.isDurak ? '#b13030' : eloResult.isWinner ? '#d4af37' : '#d8c89c';
-          const deltaColor = eloResult.delta >= 0 ? '#f4d774' : '#ff7a7a';
-          return (
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center"
-              style={{ background: 'rgba(0,0,0,0.86)', backdropFilter: 'blur(10px)' }}
-              onClick={clearEloResult}
-            >
-              <div
-                className="flex flex-col items-center text-center"
-                style={{
-                  gap: 22,
-                  padding: '34px 40px',
-                  borderRadius: 22,
-                  minWidth: 300,
-                  background:
-                    'linear-gradient(180deg, rgba(10,54,36,0.96) 0%, rgba(7,38,26,0.96) 60%, rgba(4,21,14,0.98) 100%)',
-                  border: `2px solid ${accent}`,
-                  boxShadow: `0 0 80px ${accent}55, 0 24px 60px rgba(0,0,0,0.85), inset 0 1px 0 rgba(255,255,255,0.06)`,
-                  position: 'relative',
-                }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div
-                  aria-hidden
-                  style={{
-                    position: 'absolute',
-                    inset: 6,
-                    borderRadius: 18,
-                    border: '1px solid rgba(212,175,55,0.35)',
-                    pointerEvents: 'none',
-                  }}
-                />
-                <div style={{ fontSize: 60, lineHeight: 1 }}>
-                  {eloResult.isDurak ? '💀' : eloResult.isWinner ? '👑' : '🤝'}
-                </div>
-                <div>
-                  <div
-                    style={{
-                      fontFamily: "'Cinzel', Georgia, serif",
-                      fontWeight: 900,
-                      fontSize: 22,
-                      color: '#f4d774',
-                      letterSpacing: 3,
-                      textTransform: 'uppercase',
-                      textShadow: '0 2px 8px rgba(0,0,0,0.7)',
-                    }}
-                  >
-                    {eloResult.isDurak ? 'The Durak' : eloResult.isWinner ? 'Victory' : 'Game Over'}
-                  </div>
-                  <div
-                    style={{
-                      fontFamily: "'Cinzel', Georgia, serif",
-                      fontSize: 10,
-                      color: '#d8c89c',
-                      marginTop: 6,
-                      letterSpacing: 3,
-                      textTransform: 'uppercase',
-                      opacity: 0.7,
-                    }}
-                  >
-                    Ranked Result
-                  </div>
-                </div>
-                <div
-                  style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}
-                >
-                  <div
-                    style={{
-                      fontFamily: "'Cinzel', Georgia, serif",
-                      fontSize: 48,
-                      fontWeight: 900,
-                      color: deltaColor,
-                      letterSpacing: -1,
-                      textShadow: `0 0 20px ${deltaColor}55`,
-                    }}
-                  >
-                    {eloResult.delta >= 0 ? '+' : ''}
-                    {eloResult.delta}
-                  </div>
-                  <div
-                    style={{
-                      fontSize: 12,
-                      color: '#d8c89c',
-                      fontWeight: 600,
-                      letterSpacing: 2,
-                      textTransform: 'uppercase',
-                    }}
-                  >
-                    {eloResult.oldElo} →{' '}
-                    <span style={{ color: '#f4d774', fontFamily: "'Cinzel', Georgia, serif" }}>
-                      {eloResult.newElo}
-                    </span>{' '}
-                    ELO
-                  </div>
-                </div>
-                <button
-                  onClick={clearEloResult}
-                  style={{
-                    padding: '12px 32px',
-                    borderRadius: 999,
-                    fontFamily: "'Cinzel', Georgia, serif",
-                    fontWeight: 800,
-                    fontSize: 13,
-                    letterSpacing: 2.5,
-                    textTransform: 'uppercase',
-                    background: 'linear-gradient(135deg, #f4d774 0%, #d4af37 50%, #8b6914 100%)',
-                    border: '1.5px solid rgba(212,175,55,0.7)',
-                    color: '#1a1308',
-                    textShadow: '0 1px 0 rgba(255,255,255,0.3)',
-                    boxShadow: '0 8px 22px rgba(0,0,0,0.5), 0 0 22px rgba(212,175,55,0.4)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  Continue
-                </button>
-              </div>
-            </div>
-          );
-        })()}
-
-      {/* ── Rematch overlay ── */}
-      {gameState.phase === 'finished' && !eloResult && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center"
-          style={{ background: 'rgba(0,0,0,0.78)', backdropFilter: 'blur(8px)' }}
-        >
-          <div
-            className="flex flex-col items-center text-center"
-            style={{
-              gap: 18,
-              padding: '28px 36px',
-              borderRadius: 22,
-              minWidth: 300,
-              background: 'linear-gradient(180deg, rgba(10,54,36,0.95), rgba(4,21,14,0.98))',
-              border: '1.5px solid rgba(212,175,55,0.4)',
-              boxShadow: '0 24px 60px rgba(0,0,0,0.85), inset 0 1px 0 rgba(255,255,255,0.06)',
-              position: 'relative',
-            }}
-          >
-            <div
-              aria-hidden
-              style={{
-                position: 'absolute',
-                inset: 6,
-                borderRadius: 18,
-                border: '1px solid rgba(212,175,55,0.3)',
-                pointerEvents: 'none',
-              }}
-            />
-            <div
-              style={{
-                fontFamily: "'Cinzel', Georgia, serif",
-                fontSize: 12,
-                fontWeight: 700,
-                color: '#f4d774',
-                letterSpacing: 3,
-                textTransform: 'uppercase',
-                textShadow: '0 1px 2px rgba(0,0,0,0.6)',
-              }}
-            >
-              {rematchState
-                ? `${rematchState.votes} / ${rematchState.needed} call for a rematch`
-                : 'Game Over'}
-            </div>
-            {rematchState && rematchState.voters.length > 0 && (
-              <div style={{ fontSize: 11, color: '#d8c89c', opacity: 0.75, fontStyle: 'italic' }}>
-                {rematchState.voters.join(', ')} ✓
-              </div>
-            )}
-            <div className="flex gap-3">
-              <button
-                onClick={() => sendRematchVote(true)}
-                style={{
-                  padding: '12px 24px',
-                  borderRadius: 14,
-                  fontFamily: "'Cinzel', Georgia, serif",
-                  fontWeight: 800,
-                  fontSize: 13,
-                  letterSpacing: 2,
-                  textTransform: 'uppercase',
-                  cursor: 'pointer',
-                  background: 'linear-gradient(135deg, #f4d774 0%, #d4af37 50%, #8b6914 100%)',
-                  border: '1.5px solid rgba(212,175,55,0.7)',
-                  color: '#1a1308',
-                  textShadow: '0 1px 0 rgba(255,255,255,0.3)',
-                  boxShadow: '0 8px 22px rgba(0,0,0,0.5), 0 0 22px rgba(212,175,55,0.4)',
-                }}
-              >
-                ♛ Rematch
-              </button>
-              <button
-                onClick={() => sendRematchVote(false)}
-                style={{
-                  padding: '12px 24px',
-                  borderRadius: 14,
-                  fontFamily: "'Cinzel', Georgia, serif",
-                  fontWeight: 800,
-                  fontSize: 13,
-                  letterSpacing: 2,
-                  textTransform: 'uppercase',
-                  cursor: 'pointer',
-                  background: 'linear-gradient(135deg, #b13030, #5b1818)',
-                  border: '1.5px solid #8b2121',
-                  color: '#f5ead0',
-                  textShadow: '0 1px 2px rgba(0,0,0,0.6)',
-                }}
-              >
-                Leave
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* ELO result and rematch are now part of the unified game-over overlay below */}
 
       {/* ── Game aborted overlay ── */}
       {gameAbortReason && (
@@ -2618,153 +2404,312 @@ export const GameBoard: React.FC = () => {
           role="dialog"
           aria-modal="true"
           aria-labelledby="game-over-title"
-          style={{
-            background: 'rgba(0,0,0,0.85)',
-            backdropFilter: 'blur(8px)',
-          }}
+          style={{ background: 'rgba(0,0,0,0.85)', backdropFilter: 'blur(8px)' }}
         >
           {(() => {
-            const isLoser = gameState.loser === room.sessionId;
-            const isDraw = gameState.loser === null;
+            const isLoser = !!gameState.loser && gameState.loser === room.sessionId;
+            const isDraw = !gameState.loser; // loser is '' when everyone finished simultaneously
             const isWinner = !isLoser && !isDraw;
             const accent = isLoser ? '#b13030' : isDraw ? '#3b82f6' : '#d4af37';
             const icon = isLoser ? '🥴' : isDraw ? '🤝' : '👑';
             const title = isLoser ? 'You Are the Durak' : isDraw ? 'Draw' : 'You Survived';
-            const subtitle = isLoser
-              ? 'Better luck next round.'
-              : isDraw
-                ? 'A gentleman’s tie.'
-                : `The fool is ${gameState.loser?.slice(0, 5)}…`;
+            // Determine whose loser name to show
+            const loserName =
+              gameState.players.get(gameState.loser ?? '')?.username ??
+              gameState.loser?.slice(0, 8);
+
+            const deltaColor = eloResult
+              ? eloResult.delta >= 0
+                ? '#f4d774'
+                : '#ff7a7a'
+              : '#f4d774';
+
             return (
               <div
                 className="text-center"
                 style={{
-                  width: '90%',
-                  maxWidth: 480,
-                  padding: '32px 28px 28px',
+                  width: '92%',
+                  maxWidth: 400,
                   borderRadius: 22,
                   background:
-                    'linear-gradient(180deg, rgba(10,54,36,0.95) 0%, rgba(7,38,26,0.95) 60%, rgba(4,21,14,0.98) 100%)',
+                    'linear-gradient(180deg, rgba(10,54,36,0.97) 0%, rgba(7,38,26,0.97) 60%, rgba(4,21,14,0.99) 100%)',
                   border: `2px solid ${accent}`,
-                  boxShadow: `0 0 80px ${accent}55, 0 24px 60px rgba(0,0,0,0.85), inset 0 1px 0 rgba(255,255,255,0.06)`,
+                  boxShadow: `0 0 80px ${accent}44, 0 24px 60px rgba(0,0,0,0.85), inset 0 1px 0 rgba(255,255,255,0.06)`,
                   position: 'relative',
+                  overflow: 'hidden',
                 }}
               >
-                {/* Ornate gold frame */}
+                {/* Ornate inner frame */}
                 <div
                   aria-hidden
                   style={{
                     position: 'absolute',
                     inset: 6,
-                    borderRadius: 18,
-                    border: '1px solid rgba(212,175,55,0.4)',
+                    borderRadius: 17,
+                    border: '1px solid rgba(212,175,55,0.3)',
                     pointerEvents: 'none',
                   }}
                 />
+
+                {/* Result section */}
+                <div style={{ padding: '28px 28px 20px' }}>
+                  <div style={{ fontSize: 58, lineHeight: 1, marginBottom: 12 }} aria-hidden>
+                    {icon}
+                  </div>
+                  <h2
+                    id="game-over-title"
+                    style={{
+                      fontFamily: "'Cinzel', Georgia, serif",
+                      fontSize: 26,
+                      fontWeight: 900,
+                      letterSpacing: 3,
+                      textTransform: 'uppercase',
+                      color: isWinner ? '#f4d774' : isLoser ? '#ff7a7a' : '#bfdbfe',
+                      textShadow: `0 2px 12px ${accent}66`,
+                      margin: '0 0 6px',
+                    }}
+                  >
+                    {title}
+                  </h2>
+                  <p
+                    style={{
+                      color: '#d8c89c',
+                      fontSize: 12,
+                      opacity: 0.8,
+                      margin: 0,
+                      fontStyle: 'italic',
+                    }}
+                  >
+                    {isDraw
+                      ? "A gentleman's tie."
+                      : isLoser
+                        ? 'Better luck next round.'
+                        : `${loserName} is the Durak`}
+                  </p>
+                </div>
+
+                {/* ELO change (ranked games only) */}
+                {eloResult && (
+                  <div
+                    style={{
+                      margin: '0 20px',
+                      padding: '14px 20px',
+                      borderRadius: 12,
+                      background: 'rgba(0,0,0,0.35)',
+                      border: '1px solid rgba(212,175,55,0.2)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontFamily: "'Cinzel', Georgia, serif",
+                        fontSize: 10,
+                        fontWeight: 700,
+                        color: '#d8c89c',
+                        letterSpacing: 2,
+                        textTransform: 'uppercase',
+                        opacity: 0.7,
+                      }}
+                    >
+                      Ranked ELO
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <span
+                        style={{
+                          fontFamily: "'Cinzel', Georgia, serif",
+                          fontSize: 13,
+                          color: '#d8c89c',
+                          opacity: 0.6,
+                        }}
+                      >
+                        {eloResult.oldElo}
+                      </span>
+                      <span style={{ color: '#d8c89c', opacity: 0.4, fontSize: 11 }}>→</span>
+                      <span
+                        style={{
+                          fontFamily: "'Cinzel', Georgia, serif",
+                          fontSize: 15,
+                          fontWeight: 900,
+                          color: '#f4d774',
+                        }}
+                      >
+                        {eloResult.newElo}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: "'Cinzel', Georgia, serif",
+                          fontSize: 16,
+                          fontWeight: 900,
+                          color: deltaColor,
+                          textShadow: `0 0 12px ${deltaColor}66`,
+                          minWidth: 44,
+                          textAlign: 'right',
+                        }}
+                      >
+                        {eloResult.delta >= 0 ? '+' : ''}
+                        {eloResult.delta}
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Divider */}
                 <div
                   style={{
                     display: 'flex',
                     alignItems: 'center',
-                    justifyContent: 'center',
                     gap: 10,
-                    marginBottom: 8,
+                    margin: '20px 28px 16px',
                   }}
                 >
                   <div
                     style={{
-                      width: 50,
+                      flex: 1,
                       height: 1,
-                      background: `linear-gradient(90deg, transparent, ${accent})`,
+                      background: `linear-gradient(90deg, transparent, rgba(212,175,55,0.3))`,
                     }}
                   />
-                  <span style={{ color: accent, fontSize: 9 }}>◆</span>
+                  <span style={{ color: 'rgba(212,175,55,0.4)', fontSize: 9 }}>◆</span>
                   <div
                     style={{
-                      width: 50,
+                      flex: 1,
                       height: 1,
-                      background: `linear-gradient(90deg, ${accent}, transparent)`,
+                      background: `linear-gradient(90deg, rgba(212,175,55,0.3), transparent)`,
                     }}
                   />
                 </div>
-                <div style={{ fontSize: 64, lineHeight: 1, marginBottom: 16 }} aria-hidden>
-                  {icon}
-                </div>
-                <h2
-                  id="game-over-title"
-                  style={{
-                    fontFamily: "'Cinzel', Georgia, serif",
-                    fontSize: 30,
-                    fontWeight: 900,
-                    letterSpacing: 4,
-                    textTransform: 'uppercase',
-                    color: isWinner ? '#f4d774' : isLoser ? '#ff7a7a' : '#bfdbfe',
-                    textShadow: `0 2px 12px ${accent}66, 0 1px 2px rgba(0,0,0,0.8)`,
-                    margin: '0 0 6px',
-                  }}
-                >
-                  {title}
-                </h2>
-                <p
-                  style={{
-                    color: '#d8c89c',
-                    fontSize: 13,
-                    opacity: 0.85,
-                    margin: '0 0 8px',
-                    fontStyle: 'italic',
-                  }}
-                >
-                  {subtitle}
-                </p>
+
+                {/* Rematch voting status */}
+                {rematchState && (
+                  <div
+                    style={{
+                      margin: '0 20px 14px',
+                      padding: '10px 16px',
+                      borderRadius: 10,
+                      background: 'rgba(212,175,55,0.08)',
+                      border: '1px solid rgba(212,175,55,0.2)',
+                      textAlign: 'center',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontFamily: "'Cinzel', Georgia, serif",
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: '#f4d774',
+                        letterSpacing: 2,
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      {rematchState.votes} / {rematchState.needed} want a rematch
+                    </div>
+                    {rematchState.voters.length > 0 && (
+                      <div
+                        style={{
+                          fontSize: 11,
+                          color: '#d8c89c',
+                          marginTop: 4,
+                          opacity: 0.7,
+                          fontStyle: 'italic',
+                        }}
+                      >
+                        {rematchState.voters.join(', ')} ✓
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Action buttons */}
                 <div
                   style={{
                     display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
                     gap: 10,
-                    margin: '18px 0',
+                    padding: '0 20px 24px',
                   }}
                 >
-                  <div
+                  {!isSpectator &&
+                    (hasVotedRematch ? (
+                      <div
+                        style={{
+                          flex: 1,
+                          padding: '13px 0',
+                          borderRadius: 14,
+                          background: 'rgba(212,175,55,0.08)',
+                          border: '1px solid rgba(212,175,55,0.2)',
+                          fontFamily: "'Cinzel', Georgia, serif",
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: '#f4d774',
+                          letterSpacing: 1.5,
+                          textTransform: 'uppercase',
+                          textAlign: 'center',
+                        }}
+                      >
+                        ✓ Waiting…
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => {
+                          setHasVotedRematch(true);
+                          sendRematchVote(true);
+                        }}
+                        style={{
+                          flex: 1,
+                          padding: '13px 0',
+                          borderRadius: 14,
+                          fontFamily: "'Cinzel', Georgia, serif",
+                          fontWeight: 800,
+                          fontSize: 13,
+                          letterSpacing: 2,
+                          textTransform: 'uppercase',
+                          cursor: 'pointer',
+                          background:
+                            'linear-gradient(135deg, #f4d774 0%, #d4af37 50%, #8b6914 100%)',
+                          border: '1.5px solid rgba(212,175,55,0.7)',
+                          color: '#1a1308',
+                          textShadow: '0 1px 0 rgba(255,255,255,0.3)',
+                          boxShadow: '0 6px 18px rgba(0,0,0,0.45), 0 0 18px rgba(212,175,55,0.35)',
+                          transition: 'transform 0.05s',
+                        }}
+                        onMouseDown={(e) => (e.currentTarget.style.transform = 'scale(0.97)')}
+                        onMouseUp={(e) => (e.currentTarget.style.transform = '')}
+                        onMouseLeave={(e) => (e.currentTarget.style.transform = '')}
+                      >
+                        ♛ Rematch
+                      </button>
+                    ))}
+                  <button
+                    onClick={leaveGame}
                     style={{
-                      width: 50,
-                      height: 1,
-                      background: `linear-gradient(90deg, transparent, ${accent})`,
+                      flex: isSpectator ? 1 : undefined,
+                      padding: '13px 20px',
+                      borderRadius: 14,
+                      fontFamily: "'Cinzel', Georgia, serif",
+                      fontWeight: 800,
+                      fontSize: 13,
+                      letterSpacing: 2,
+                      textTransform: 'uppercase',
+                      cursor: 'pointer',
+                      background: 'linear-gradient(135deg, #2a2018, #1a140e)',
+                      border: '1.5px solid rgba(212,175,55,0.25)',
+                      color: '#d8c89c',
+                      transition: 'transform 0.05s, border-color 0.15s',
                     }}
-                  />
-                  <span style={{ color: accent, fontSize: 9 }}>◆</span>
-                  <div
-                    style={{
-                      width: 50,
-                      height: 1,
-                      background: `linear-gradient(90deg, ${accent}, transparent)`,
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.borderColor = 'rgba(212,175,55,0.55)')
+                    }
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.borderColor = 'rgba(212,175,55,0.25)';
+                      e.currentTarget.style.transform = '';
                     }}
-                  />
+                    onMouseDown={(e) => (e.currentTarget.style.transform = 'scale(0.97)')}
+                    onMouseUp={(e) => (e.currentTarget.style.transform = '')}
+                  >
+                    Leave
+                  </button>
                 </div>
-                <button
-                  onClick={handleStartGame}
-                  style={{
-                    padding: '14px 32px',
-                    borderRadius: 999,
-                    fontFamily: "'Cinzel', Georgia, serif",
-                    fontWeight: 800,
-                    fontSize: 14,
-                    letterSpacing: 2.5,
-                    textTransform: 'uppercase',
-                    color: '#1a1308',
-                    background: 'linear-gradient(135deg, #f4d774 0%, #d4af37 50%, #8b6914 100%)',
-                    border: '1.5px solid rgba(212,175,55,0.7)',
-                    boxShadow:
-                      '0 12px 32px rgba(0,0,0,0.55), 0 0 26px rgba(212,175,55,0.45), inset 0 1px 0 rgba(255,255,255,0.3)',
-                    cursor: 'pointer',
-                    textShadow: '0 1px 0 rgba(255,255,255,0.3)',
-                    transition: 'transform 0.05s',
-                  }}
-                  onMouseDown={(e) => (e.currentTarget.style.transform = 'scale(0.96)')}
-                  onMouseUp={(e) => (e.currentTarget.style.transform = '')}
-                  onMouseLeave={(e) => (e.currentTarget.style.transform = '')}
-                >
-                  ♛ Play Again
-                </button>
               </div>
             );
           })()}

--- a/packages/client/src/components/HomePage.tsx
+++ b/packages/client/src/components/HomePage.tsx
@@ -432,7 +432,17 @@ function SinglePlayerSheet() {
 
 // ── Custom Lobby sheet ────────────────────────────────────────────────────────
 
-function CustomLobbySheet({ discordId, userId }: { discordId?: string; userId?: string }) {
+function CustomLobbySheet({
+  discordId,
+  userId,
+  username,
+  avatarUrl,
+}: {
+  discordId?: string;
+  userId?: string;
+  username?: string;
+  avatarUrl?: string;
+}) {
   const { createGame, joinGame, spectateGame, findPublicGames } = useGame();
   const [tab, setTab] = useState<'create' | 'join' | 'browse'>('create');
   const [isLoading, setIsLoading] = useState(false);
@@ -572,7 +582,17 @@ function CustomLobbySheet({ discordId, userId }: { discordId?: string; userId?: 
             loading={isLoading}
             onClick={async () => {
               setIsLoading(true);
-              await createGame({ maxPlayers, isPrivate: true, mode, teamSelection, handSize });
+              await createGame({
+                maxPlayers,
+                isPrivate: true,
+                mode,
+                teamSelection,
+                handSize,
+                ...(discordId ? { discordId } : {}),
+                ...(userId ? { userId } : {}),
+                ...(username ? { username } : {}),
+                ...(avatarUrl ? { avatarUrl } : {}),
+              });
               setIsLoading(false);
             }}
           >
@@ -608,7 +628,7 @@ function CustomLobbySheet({ discordId, userId }: { discordId?: string; userId?: 
             onClick={async () => {
               if (!joinCode.trim()) return;
               setIsLoading(true);
-              await joinGame(joinCode.trim(), discordId, userId);
+              await joinGame(joinCode.trim(), discordId, userId, username, avatarUrl);
               setIsLoading(false);
             }}
           >
@@ -702,7 +722,7 @@ function CustomLobbySheet({ discordId, userId }: { discordId?: string; userId?: 
                       size="sm"
                       variant={full ? 'ghost' : 'gold'}
                       disabled={isLoading || full}
-                      onClick={() => joinGame(r.roomId, discordId, userId)}
+                      onClick={() => joinGame(r.roomId, discordId, userId, username, avatarUrl)}
                     >
                       Join
                     </GoldButton>
@@ -822,7 +842,13 @@ const ModeCard: React.FC<{
 
 // ── Main HomePage ─────────────────────────────────────────────────────────────
 
-export const HomePage: React.FC<HomePageProps> = ({ discordId, userId, error }) => {
+export const HomePage: React.FC<HomePageProps> = ({
+  discordId,
+  userId,
+  username,
+  avatarUrl,
+  error,
+}) => {
   const { joinOrCreateGame, leaveGame } = useGame();
   const [phase, setPhase] = useState<'intro' | 'home'>('intro');
   const [homeState, setHomeState] = useState<HomeState>('home');
@@ -862,7 +888,16 @@ export const HomePage: React.FC<HomePageProps> = ({ discordId, userId, error }) 
       return;
     }
 
-    await joinOrCreateGame({ ...opts, isPrivate: false, teamSelection: 'random', eloTier });
+    await joinOrCreateGame({
+      ...opts,
+      isPrivate: false,
+      teamSelection: 'random',
+      eloTier,
+      ...(discordId ? { discordId } : {}),
+      ...(userId ? { userId } : {}),
+      ...(username ? { username } : {}),
+      ...(avatarUrl ? { avatarUrl } : {}),
+    });
 
     // If the user cancelled while joinOrCreate was in flight, immediately leave.
     if (cancelRef.current) {
@@ -1161,7 +1196,12 @@ export const HomePage: React.FC<HomePageProps> = ({ discordId, userId, error }) 
             }
             onClose={() => setSheet(null)}
           >
-            <CustomLobbySheet discordId={discordId} userId={userId} />
+            <CustomLobbySheet
+              discordId={discordId}
+              userId={userId}
+              username={username}
+              avatarUrl={avatarUrl}
+            />
           </Sheet>
         )}
         {sheet === 'solo' && (

--- a/packages/client/src/components/ProfilePage.tsx
+++ b/packages/client/src/components/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useGame } from '../contexts/GameContext';
 import { BADGES } from '@durak/shared';
 
 interface ProfileStats {
@@ -46,23 +47,25 @@ const API = '/api';
 
 export const ProfilePage: React.FC = () => {
   const { user, logout } = useAuth();
+  const { latestStats } = useGame();
   const [profile, setProfile] = useState<Profile | null>(null);
   const [history, setHistory] = useState<MatchRecord[]>([]);
   const [leaders, setLeaders] = useState<LeaderEntry[]>([]);
   const [tab, setTab] = useState<'stats' | 'history' | 'leaderboard'>('stats');
   const [leaderMode, setLeaderMode] = useState<'classic' | 'teams'>('classic');
   const [loading, setLoading] = useState(!!user?.id);
+  const [filterMode, setFilterMode] = useState<'all' | 'classic' | 'teams'>('all');
+  const [filterResult, setFilterResult] = useState<'all' | 'win' | 'durak' | 'loss'>('all');
 
   const id = user?.id ?? '';
   const byParam = user?.method === 'email' ? '?by=user' : '';
 
-  useEffect(() => {
+  const fetchProfile = React.useCallback(() => {
     if (!id) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     Promise.all([
       fetch(`${API}/profile/${id}${byParam}`).then((r) => (r.ok ? r.json() : null)),
-      fetch(`${API}/history/${id}?limit=20${byParam ? '&by=user' : ''}`).then((r) =>
+      fetch(`${API}/history/${id}?limit=50${byParam ? '&by=user' : ''}`).then((r) =>
         r.ok ? r.json() : [],
       ),
     ])
@@ -73,6 +76,10 @@ export const ProfilePage: React.FC = () => {
       .catch(() => setHistory([]))
       .finally(() => setLoading(false));
   }, [id, byParam]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
 
   useEffect(() => {
     if (tab !== 'leaderboard') return;
@@ -98,8 +105,29 @@ export const ProfilePage: React.FC = () => {
     );
   }
 
-  const stats = profile?.stats;
+  // latestStats is pushed from the server after the DB write completes — always authoritative.
+  // Fall back to the HTTP-fetched profile for users who haven't played a game this session.
+  const stats = latestStats?.stats ?? profile?.stats;
+  const eloClassic = latestStats?.eloClassic ?? profile?.eloClassic ?? 1000;
+  const eloTeams = latestStats?.eloTeams ?? profile?.eloTeams ?? 1000;
+  const coins = latestStats?.coins ?? profile?.coins ?? 0;
+  const badges = latestStats?.badges ?? profile?.badges ?? [];
   const winRate = stats?.gamesPlayed ? Math.round((stats.wins / stats.gamesPlayed) * 100) : 0;
+  const durakRate = stats?.gamesPlayed
+    ? Math.round((stats.durakCount / stats.gamesPlayed) * 100)
+    : 0;
+
+  const filteredHistory = history.filter((m) => {
+    if (filterMode !== 'all' && m.mode !== filterMode) return false;
+    if (filterResult !== 'all') {
+      const won = m.winners.includes(id);
+      const wasDurak = m.durak === id;
+      if (filterResult === 'win' && !won) return false;
+      if (filterResult === 'durak' && !wasDurak) return false;
+      if (filterResult === 'loss' && (won || wasDurak)) return false;
+    }
+    return true;
+  });
 
   return (
     <div className="min-h-screen bg-transparent text-white pb-24">
@@ -126,9 +154,9 @@ export const ProfilePage: React.FC = () => {
             </div>
             <div className="flex items-center gap-3 mt-2 flex-wrap">
               <span className="text-[var(--gold-400)] text-sm font-bold tracking-wider">
-                ★ {profile?.eloClassic ?? 1000} ELO
+                ★ {eloClassic} ELO
               </span>
-              {profile && (
+              {(profile || latestStats) && (
                 <span className="text-[var(--gold-300)] text-sm font-bold flex items-center gap-1.5 tracking-wider">
                   <img
                     src="/assets/coin.png"
@@ -142,18 +170,28 @@ export const ProfilePage: React.FC = () => {
                       filter: 'drop-shadow(0 1px 3px rgba(0,0,0,0.5))',
                     }}
                   />
-                  <span>{(profile.coins ?? 0).toLocaleString()}</span>
+                  <span>{coins.toLocaleString()}</span>
                 </span>
               )}
             </div>
           </div>
-          <button
-            onClick={logout}
-            className="text-xs text-[var(--gold-400)] hover:text-red-400 transition font-black uppercase tracking-widest cursor-pointer shrink-0"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
-            Sign out
-          </button>
+          <div className="flex flex-col items-end gap-2 shrink-0">
+            <button
+              onClick={logout}
+              className="text-xs text-[var(--gold-400)] hover:text-red-400 transition font-black uppercase tracking-widest cursor-pointer"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              Sign out
+            </button>
+            <button
+              onClick={fetchProfile}
+              disabled={loading}
+              className="text-[10px] text-[var(--ivory-300)] hover:text-[var(--gold-400)] transition font-bold uppercase tracking-widest cursor-pointer opacity-70 disabled:opacity-30"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              ↻ Refresh
+            </button>
+          </div>
         </div>
       </div>
 
@@ -188,11 +226,47 @@ export const ProfilePage: React.FC = () => {
         ) : tab === 'stats' ? (
           stats ? (
             <div className="space-y-4">
+              {/* W/L/D bar */}
+              {stats.gamesPlayed > 0 && (
+                <div className="casino-panel p-4 border-[rgba(212,175,55,0.18)]">
+                  <div className="flex justify-between text-[10px] font-bold uppercase tracking-widest mb-2 opacity-75">
+                    <span className="text-emerald-400">{stats.wins}W</span>
+                    <span className="text-[var(--ivory-300)]">
+                      {stats.gamesPlayed - stats.wins - stats.durakCount} Middle
+                    </span>
+                    <span className="text-red-400">{stats.durakCount}D</span>
+                  </div>
+                  <div className="flex rounded-full overflow-hidden h-2.5 gap-px bg-black/40">
+                    {stats.wins > 0 && (
+                      <div
+                        className="bg-emerald-500 transition-all"
+                        style={{ width: `${(stats.wins / stats.gamesPlayed) * 100}%` }}
+                      />
+                    )}
+                    {stats.gamesPlayed - stats.wins - stats.durakCount > 0 && (
+                      <div
+                        className="bg-[var(--gold-700)] transition-all"
+                        style={{
+                          width: `${((stats.gamesPlayed - stats.wins - stats.durakCount) / stats.gamesPlayed) * 100}%`,
+                        }}
+                      />
+                    )}
+                    {stats.durakCount > 0 && (
+                      <div
+                        className="bg-red-600 transition-all"
+                        style={{ width: `${(stats.durakCount / stats.gamesPlayed) * 100}%` }}
+                      />
+                    )}
+                  </div>
+                </div>
+              )}
               <div className="grid grid-cols-2 gap-3">
                 <StatCard label="Games" value={stats.gamesPlayed} />
                 <StatCard label="Win Rate" value={`${winRate}%`} highlight={winRate >= 50} />
                 <StatCard label="Wins" value={stats.wins} highlight />
-                <StatCard label="Durak" value={stats.durakCount} dim />
+                <StatCard label="Durak Rate" value={`${durakRate}%`} dim={durakRate > 30} />
+                <StatCard label="Durak Count" value={stats.durakCount} dim />
+                <StatCard label="Losses" value={stats.losses} dim />
                 <StatCard
                   label="Win Streak"
                   value={stats.winStreak}
@@ -206,7 +280,7 @@ export const ProfilePage: React.FC = () => {
                     className="text-[var(--gold-400)] font-black text-2xl font-display"
                     style={{ fontFamily: 'var(--font-display)' }}
                   >
-                    ★ {profile?.eloClassic ?? 1000}
+                    ★ {eloClassic}
                   </div>
                   <div className="text-[var(--ivory-300)] text-[10px] font-bold uppercase tracking-widest mt-1 opacity-75">
                     Classic ELO
@@ -217,14 +291,14 @@ export const ProfilePage: React.FC = () => {
                     className="text-[var(--gold-400)] font-black text-2xl font-display"
                     style={{ fontFamily: 'var(--font-display)' }}
                   >
-                    ★ {profile?.eloTeams ?? 1000}
+                    ★ {eloTeams}
                   </div>
                   <div className="text-[var(--ivory-300)] text-[10px] font-bold uppercase tracking-widest mt-1 opacity-75">
                     Teams ELO
                   </div>
                 </div>
               </div>
-              <BadgesSection earned={profile?.badges ?? []} />
+              <BadgesSection earned={badges} />
             </div>
           ) : (
             <div className="text-[var(--ivory-300)] text-sm text-center py-12 italic opacity-60">
@@ -232,7 +306,53 @@ export const ProfilePage: React.FC = () => {
             </div>
           )
         ) : tab === 'history' ? (
-          <HistoryList history={history} byUser={user.method === 'email'} />
+          <div className="space-y-3">
+            {/* Filter bar */}
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-1.5 flex-wrap">
+                {(['all', 'classic', 'teams'] as const).map((m) => (
+                  <button
+                    key={m}
+                    onClick={() => setFilterMode(m)}
+                    className={`px-3 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest border transition cursor-pointer ${
+                      filterMode === m
+                        ? 'bg-[var(--gradient-gold)] text-[var(--ink-900)] border-[rgba(212,175,55,0.7)]'
+                        : 'bg-transparent text-[var(--ivory-300)] border-[rgba(212,175,55,0.2)] hover:border-[rgba(212,175,55,0.5)]'
+                    }`}
+                    style={{ fontFamily: 'var(--font-display)' }}
+                  >
+                    {m === 'all' ? 'All Modes' : m}
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-1.5 flex-wrap">
+                {(['all', 'win', 'durak', 'loss'] as const).map((r) => (
+                  <button
+                    key={r}
+                    onClick={() => setFilterResult(r)}
+                    className={`px-3 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest border transition cursor-pointer ${
+                      filterResult === r
+                        ? r === 'win'
+                          ? 'bg-emerald-600 text-white border-emerald-500'
+                          : r === 'durak'
+                            ? 'bg-red-700 text-white border-red-600'
+                            : r === 'loss'
+                              ? 'bg-[rgba(212,175,55,0.15)] text-[var(--gold-300)] border-[rgba(212,175,55,0.5)]'
+                              : 'bg-[var(--gradient-gold)] text-[var(--ink-900)] border-[rgba(212,175,55,0.7)]'
+                        : 'bg-transparent text-[var(--ivory-300)] border-[rgba(212,175,55,0.2)] hover:border-[rgba(212,175,55,0.5)]'
+                    }`}
+                    style={{ fontFamily: 'var(--font-display)' }}
+                  >
+                    {r === 'all' ? 'All Results' : r}
+                  </button>
+                ))}
+              </div>
+              <div className="text-[var(--ivory-300)] text-[10px] opacity-60 font-semibold tracking-wider">
+                {filteredHistory.length} of {history.length} games
+              </div>
+            </div>
+            <HistoryList history={filteredHistory} playerId={id} />
+          </div>
         ) : (
           <LeaderboardSection
             leaders={leaders}
@@ -295,8 +415,8 @@ const BadgesSection: React.FC<{ earned: string[] }> = ({ earned }) => {
 
 const HistoryList: React.FC<{
   history: MatchRecord[];
-  byUser: boolean;
-}> = ({ history, byUser }) => {
+  playerId: string;
+}> = ({ history, playerId }) => {
   if (history.length === 0) {
     return (
       <div className="text-[var(--ivory-300)] text-sm text-center py-12 italic opacity-60">
@@ -307,9 +427,8 @@ const HistoryList: React.FC<{
   return (
     <div className="space-y-2">
       {history.map((m) => {
-        const myIds = byUser ? m.userIds : m.discordIds;
-        const won = m.winners.some((w) => myIds.includes(w));
-        const wasDurak = myIds.includes(m.durak ?? '');
+        const won = m.winners.includes(playerId);
+        const wasDurak = m.durak === playerId;
         const result = won ? 'Win' : wasDurak ? 'Durak' : 'Loss';
         const color = won
           ? 'text-emerald-400'

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -52,13 +52,33 @@ interface GameContextState {
     isDurak: boolean;
   } | null;
   clearEloResult: () => void;
+  latestStats: {
+    eloClassic: number;
+    eloTeams: number;
+    stats: {
+      gamesPlayed: number;
+      wins: number;
+      losses: number;
+      durakCount: number;
+      winStreak: number;
+      durakFreeStreak: number;
+    };
+    coins: number;
+    badges: string[];
+  } | null;
   rematchState: { votes: number; needed: number; voters: string[] } | null;
   gameAbortReason: string | null;
   clearGameAbortReason: () => void;
   sendRematchVote: (accept: boolean) => void;
   createGame: (options: Record<string, unknown>) => Promise<void>;
   joinOrCreateGame: (options: Record<string, unknown>) => Promise<void>;
-  joinGame: (roomId: string, discordId?: string, userId?: string) => Promise<void>;
+  joinGame: (
+    roomId: string,
+    discordId?: string,
+    userId?: string,
+    username?: string,
+    avatarUrl?: string,
+  ) => Promise<void>;
   spectateGame: (roomId: string) => Promise<void>;
   findPublicGames: () => Promise<RoomAvailable[]>;
   leaveGame: () => void;
@@ -93,6 +113,7 @@ const GameContext = createContext<GameContextState>({
   defenseRevealPairs: null,
   eloResult: null,
   clearEloResult: () => {},
+  latestStats: null,
   rematchState: null,
   gameAbortReason: null,
   clearGameAbortReason: () => {},
@@ -152,6 +173,20 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     newElo: number;
     isWinner: boolean;
     isDurak: boolean;
+  } | null>(null);
+  const [latestStats, setLatestStats] = useState<{
+    eloClassic: number;
+    eloTeams: number;
+    stats: {
+      gamesPlayed: number;
+      wins: number;
+      losses: number;
+      durakCount: number;
+      winStreak: number;
+      durakFreeStreak: number;
+    };
+    coins: number;
+    badges: string[];
   } | null>(null);
   const [rematchState, setRematchState] = useState<{
     votes: number;
@@ -316,6 +351,25 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       },
     );
     roomInstance.onMessage(
+      'statsUpdated',
+      (data: {
+        eloClassic: number;
+        eloTeams: number;
+        stats: {
+          gamesPlayed: number;
+          wins: number;
+          losses: number;
+          durakCount: number;
+          winStreak: number;
+          durakFreeStreak: number;
+        };
+        coins: number;
+        badges: string[];
+      }) => {
+        setLatestStats(data);
+      },
+    );
+    roomInstance.onMessage(
       'rematchVoted',
       (data: { sessionId: string; username: string; votes: number; needed: number }) => {
         setRematchState((prev) => ({
@@ -402,11 +456,19 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const joinGame = async (roomId: string, discordId?: string, userId?: string) => {
+  const joinGame = async (
+    roomId: string,
+    discordId?: string,
+    userId?: string,
+    username?: string,
+    avatarUrl?: string,
+  ) => {
     try {
       const opts: Record<string, string> = {};
       if (discordId) opts.discordId = discordId;
       if (userId) opts.userId = userId;
+      if (username) opts.username = username;
+      if (avatarUrl) opts.avatarUrl = avatarUrl;
       const roomInstance = await client.joinById<GameState>(roomId, opts);
       handleRoomEvents(roomInstance);
     } catch (e: unknown) {
@@ -512,6 +574,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         defenseRevealPairs,
         eloResult,
         clearEloResult,
+        latestStats,
         rematchState,
         gameAbortReason,
         clearGameAbortReason,

--- a/packages/client/src/test/GameBoard.test.tsx
+++ b/packages/client/src/test/GameBoard.test.tsx
@@ -145,6 +145,7 @@ function mockGameContext(overrides: Partial<ReturnType<typeof GameContextModule.
     defenseRevealPairs: null,
     eloResult: null,
     clearEloResult: vi.fn(),
+    latestStats: null,
     rematchState: null,
     gameAbortReason: null,
     clearGameAbortReason: vi.fn(),

--- a/packages/client/src/test/Lobby.test.tsx
+++ b/packages/client/src/test/Lobby.test.tsx
@@ -24,6 +24,7 @@ function mockGameContext(overrides: Partial<ReturnType<typeof GameContextModule.
     defenseRevealPairs: null,
     eloResult: null,
     clearEloResult: vi.fn(),
+    latestStats: null,
     rematchState: null,
     gameAbortReason: null,
     clearGameAbortReason: vi.fn(),

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -62,7 +62,7 @@ export class DurakRoom extends Room<GameState> {
       playerCount: 0,
       spectatorCount: 0,
       phase: this.state.phase,
-    });
+    }).catch(() => {});
 
     this.testModeDeck = options.testModeDeck;
 
@@ -326,7 +326,7 @@ export class DurakRoom extends Room<GameState> {
         playerCount: this.state.players.size,
         spectatorCount: this.spectators.size,
         phase: this.state.phase,
-      });
+      }).catch(() => {});
     } catch {
       // setMetadata requires an active room listing; no-op in test environments
     }
@@ -601,9 +601,32 @@ export class DurakRoom extends Room<GameState> {
     if (a.isJoker && !b.isJoker) return true;
     if (!a.isJoker && b.isJoker) return false;
     if (a.isJoker && b.isJoker) return a.rank > b.rank;
-    if (a.suit === this.state.huzurSuit && b.suit !== this.state.huzurSuit) return true;
-    if (a.suit !== this.state.huzurSuit && b.suit === this.state.huzurSuit) return false;
-    return a.rank > b.rank;
+
+    const huzur = this.state.huzurSuit.toLowerCase();
+    const aSuit = a.suit.toLowerCase();
+    const bSuit = b.suit.toLowerCase();
+
+    // 1. Trump vs Non-Trump
+    if (aSuit === huzur && bSuit !== huzur) return true;
+    if (aSuit !== huzur && bSuit === huzur) return false;
+
+    // 2. Rank Comparison (if different ranks)
+    if (a.rank !== b.rank) {
+      return a.rank > b.rank;
+    }
+
+    // 3. Suit Hierarchy Tie-breaker (if equal ranks)
+    // Strength: Trump > Spades > Hearts > Clubs > Diamonds
+    const getSuitStrength = (suit: string): number => {
+      if (suit === huzur) return 4;
+      if (suit === 'spades') return 3;
+      if (suit === 'hearts') return 2;
+      if (suit === 'clubs') return 1;
+      if (suit === 'diamonds') return 0;
+      return -1;
+    };
+
+    return getSuitStrength(aSuit) > getSuitStrength(bSuit);
   }
 
   /**
@@ -1379,12 +1402,16 @@ export class DurakRoom extends Room<GameState> {
                 ...setFields,
                 // Only mutate ELO field for ranked games
                 ...(isRanked && {
-                  [eloField]: { $max: [100, { $add: [`$${eloField}`, delta] }] },
+                  [eloField]: {
+                    $max: [100, { $add: [{ $ifNull: [`$${eloField}`, 1000] }, delta] }],
+                  },
                 }),
-                'stats.gamesPlayed': { $add: ['$stats.gamesPlayed', 1] },
-                'stats.wins': { $add: ['$stats.wins', isWinner ? 1 : 0] },
-                'stats.losses': { $add: ['$stats.losses', isDurak ? 1 : 0] },
-                'stats.durakCount': { $add: ['$stats.durakCount', isDurak ? 1 : 0] },
+                'stats.gamesPlayed': { $add: [{ $ifNull: ['$stats.gamesPlayed', 0] }, 1] },
+                'stats.wins': { $add: [{ $ifNull: ['$stats.wins', 0] }, isWinner ? 1 : 0] },
+                'stats.losses': { $add: [{ $ifNull: ['$stats.losses', 0] }, isDurak ? 1 : 0] },
+                'stats.durakCount': {
+                  $add: [{ $ifNull: ['$stats.durakCount', 0] }, isDurak ? 1 : 0],
+                },
                 'stats.winStreak': isWinner
                   ? { $add: [{ $ifNull: ['$stats.winStreak', 0] }, 1] }
                   : 0,

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -1341,14 +1341,25 @@ export class DurakRoom extends Room<GameState> {
       const userIds = players.map((p) => p?.userId ?? '');
       const winnerSessions = Array.from(this.state.winners);
 
+      // Convert session IDs to the player's stable identifier (discordId > userId > sessionId)
+      // so that GameLog.winners and GameLog.durak can be matched against the querying player's ID.
+      const effectiveId = (sessionId: string): string => {
+        const idx = sessionIds.indexOf(sessionId);
+        if (idx === -1) return sessionId;
+        return discordIds[idx] || userIds[idx] || sessionId;
+      };
+
+      const winnerIds = winnerSessions.filter((s): s is string => !!s).map(effectiveId);
+      const durakId = this.state.loser ? effectiveId(this.state.loser) : null;
+
       const log = new GameLog({
         roomId: this.roomId,
         mode: this.state.mode,
         players: sessionIds,
         discordIds,
         userIds,
-        winners: winnerSessions,
-        durak: this.state.loser,
+        winners: winnerIds,
+        durak: durakId,
         huzurSetting: this.state.huzurSuit,
         actionLog: Array.from(this.state.actionLog),
       });
@@ -1382,6 +1393,22 @@ export class DurakRoom extends Room<GameState> {
 
       // ELO deltas are only applied for ranked (non-private) games
       const eloDeltas = isRanked ? calculateEloDeltas(eloInputs) : new Map<string, number>();
+
+      // Send eloResult BEFORE the DB write so players receive it even if they leave quickly.
+      if (isRanked) {
+        for (const p of authedPlayers) {
+          const delta = eloDeltas.get(p.id) ?? 0;
+          const prof = currentProfiles[authedPlayers.indexOf(p)];
+          const oldElo = prof?.[eloField] ?? 1000;
+          const newElo = Math.max(100, oldElo + delta);
+          const isWinner = winnerSessions.includes(p.id);
+          const isDurak = this.state.loser === p.id;
+          const client = this.clients.find((c) => c.sessionId === p.id);
+          if (client) {
+            client.send('eloResult', { delta, oldElo, newElo, isWinner, isDurak });
+          }
+        }
+      }
 
       const profileOps = authedPlayers.map((p) => {
         const isWinner = winnerSessions.includes(p.id);
@@ -1426,20 +1453,19 @@ export class DurakRoom extends Room<GameState> {
       });
       const updatedProfiles = await Promise.all(profileOps);
 
-      // Send each player their personal ELO result for ranked games
-      if (isRanked) {
-        for (const p of authedPlayers) {
-          const delta = eloDeltas.get(p.id) ?? 0;
-          const prof = currentProfiles[authedPlayers.indexOf(p)];
-          const oldElo = prof?.[eloField] ?? 1000;
-          const newElo = Math.max(100, oldElo + delta);
-          const isWinner = winnerSessions.includes(p.id);
-          const isDurak = this.state.loser === p.id;
-          // Find the client by sessionId (p.id is the sessionId)
-          const client = this.clients.find((c) => c.sessionId === p.id);
-          if (client) {
-            client.send('eloResult', { delta, oldElo, newElo, isWinner, isDurak });
-          }
+      // Push final stats to each player so the profile page never shows stale data
+      for (const [i, p] of authedPlayers.entries()) {
+        const updated = updatedProfiles[i];
+        if (!updated) continue;
+        const client = this.clients.find((c) => c.sessionId === p.id);
+        if (client) {
+          client.send('statsUpdated', {
+            eloClassic: updated.eloClassic ?? 1000,
+            eloTeams: updated.eloTeams ?? 1000,
+            stats: updated.stats,
+            coins: updated.coins ?? 0,
+            badges: updated.badges ?? [],
+          });
         }
       }
 

--- a/packages/server/tests/suhuh.test.ts
+++ b/packages/server/tests/suhuh.test.ts
@@ -120,6 +120,51 @@ describe('Suhuh first-turn draw (#123)', () => {
     });
   });
 
+  describe('suit hierarchy tie-breakers', () => {
+    it('applies spades > hearts > clubs > diamonds for non-trumps of equal rank (trump is diamonds)', () => {
+      setupPlayers(['p1', 'p2', 'p3']);
+      room.state.huzurSuit = 'diamonds';
+
+      // Pop order:
+      // p1 draws Spades 10 (Trump rank 10)
+      // p2 draws Clubs 10
+      // p3 draws Hearts 10
+      // Spades is strongest non-trump, so p1 wins
+      pushDeckTop(new Card('hearts', 10), new Card('clubs', 10), new Card('spades', 10));
+
+      const { firstId } = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p1');
+    });
+
+    it('ranks trump higher than default spades ranking (trump is clubs)', () => {
+      setupPlayers(['p1', 'p2']);
+      room.state.huzurSuit = 'clubs';
+
+      // Pop order:
+      // p1 draws Clubs 10 (trump)
+      // p2 draws Spades 10 (non-trump)
+      // Clubs is trump, so Clubs 10 beats Spades 10 (p1 wins)
+      pushDeckTop(new Card('spades', 10), new Card('clubs', 10));
+
+      const { firstId } = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p1');
+    });
+
+    it('falls back to spades > hearts > clubs > diamonds when ranks tie and trump is not drawn (trump is diamonds)', () => {
+      setupPlayers(['p1', 'p2']);
+      room.state.huzurSuit = 'diamonds';
+
+      // Pop order:
+      // p1 draws Clubs 10 (strength 1)
+      // p2 draws Hearts 10 (strength 2)
+      // Hearts (2) > Clubs (1) (p2 wins)
+      pushDeckTop(new Card('hearts', 10), new Card('clubs', 10));
+
+      const { firstId } = (room as any).resolveSuhuh();
+      expect(firstId).toBe('p2');
+    });
+  });
+
   describe('fallback when deck is empty', () => {
     it('falls back to lowest-trump-in-hand when deck is empty after deal', () => {
       setupPlayers(['p1', 'p2']);


### PR DESCRIPTION
## Root causes fixed

### 1. Identity never reached the server (primary bug)
`handleFindMatch` called `joinOrCreateGame` without `discordId`/`userId`, so `authedPlayers` was `[]` for every ranked game — nothing was ever written to MongoDB.

**Fixed:** All join paths (Find Match, Create Table, Join by Code, Browse) now pass `discordId`, `userId`, `username`, and `avatarUrl`.

### 2. Aggregation pipeline broke on new-player upsert
`$add: ['$eloClassic', delta]` returns `null` when the field doesn't exist yet (new player). `$max: [100, null]` = `100`. First-game ELO was always set to 100.

**Fixed:** `$ifNull` guards on all aggregation pipeline fields (`$ifNull: ['$eloClassic', 1000]` etc.).

### 3. Race condition: profile page fetched before DB write completed
`eloResult` was sent *after* `await Promise.all(profileOps)`. Players who left quickly saw stale data.

**Fixed:** `eloResult` sent *before* `profileOps`. After `profileOps` resolves, server pushes `statsUpdated` WebSocket message with the exact written values. `ProfilePage` reads `latestStats` from `GameContext` — authoritative, no HTTP timing dependency.

### 4. History always showed "Win" for everyone
`ProfilePage.HistoryList` checked `m.winners.some(w => allPlayerIds.includes(w))` — "did anyone win this game?" — always true.

**Fixed:** `m.winners.includes(playerId)` where `playerId` is the viewing player's own ID.

### 5. Draw never shown
`isDraw = gameState.loser === null` is dead code — Colyseus `@type('string')` initialises to `''`. Fixed to `!gameState.loser`.

### 6. GameLog stored session IDs in winners/durak
`HistoryList` compared discordId against session IDs — never matched.

**Fixed:** `effectiveId()` converts session IDs to discordId/userId before storing in `GameLog.winners`/`GameLog.durak`.

### 7. Unified end-game screen
Replaced 3 overlapping overlays (`z-60` ELO popup, `z-60` rematch overlay, `z-100` game-over) with a single screen: result + inline ELO delta + live rematch vote counter + working Leave button.

## Test plan
- [ ] Play ranked (Find Match) — ELO changes and appears in profile immediately after Leave
- [ ] Play 2 ranked games — gamesPlayed, wins/durakCount increment correctly
- [ ] History shows Win/Durak/Loss correctly for each player
- [ ] Draw game shows Draw (not "You Survived") in game-over screen
- [ ] Leave button exits the game-over screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified game-over interface with rematch voting system showing real-time feedback
  * Real-time profile statistics updates immediately after each game
  * Player profiles now integrated across custom lobbies and ranked matchmaking
  * History filtering controls added to profile page

* **Bug Fixes**
  * Improved card ranking logic for first-turn draws
  * Enhanced player identifier handling for accurate stats tracking

* **Improvements**
  * Consolidated game-over UI and ELO display into single overlay
  * Optimized profile refresh mechanism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->