### PR TITLE
fix(db): updatePipeline:true — ELO/stats never wrote to MongoDB

### DIFF
--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -13,7 +13,11 @@ import pino from 'pino';
 import * as Sentry from '@sentry/node';
 
 import { DurakRoom } from './src/rooms/DurakRoom';
-import 'dotenv/config';
+// Load .env from the monorepo root first (local dev), then fall back to cwd (Docker/prod).
+// ts-node runs from packages/server/ so ../../.env resolves to the repo root.
+import dotenv from 'dotenv';
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+dotenv.config(); // cwd fallback — picks up any local packages/server/.env overrides
 import mongoose from 'mongoose';
 import { PlayerProfile } from './src/models/PlayerProfile';
 import { GameLog } from './src/models/GameLog';

--- a/packages/server/src/rooms/DurakRoom.ts
+++ b/packages/server/src/rooms/DurakRoom.ts
@@ -1448,7 +1448,7 @@ export class DurakRoom extends Room<GameState> {
               },
             },
           ],
-          { upsert: true, new: true },
+          { upsert: true, returnDocument: 'after', updatePipeline: true },
         );
       });
       const updatedProfiles = await Promise.all(profileOps);


### PR DESCRIPTION
## Problem

ELO and stats **silently failed to write** on every game. The Docker container runs Mongoose 9, which requires an explicit `updatePipeline: true` option when passing an array (aggregation pipeline) to `findOneAndUpdate`. Without it Mongoose throws:

```
MongooseError: Cannot pass an array to query updates unless the `updatePipeline` option is set.
```

The error was caught by `saveGameLog`'s outer `try/catch` and logged, but execution continued — so the game log row saved fine (plain `insert`) but the profile ELO/stats update was a no-op every single time.

## Fix

- Add `updatePipeline: true` to the `findOneAndUpdate` options in `profileOps`
- Replace deprecated `new: true` with `returnDocument: 'after'` (Mongoose 9 deprecation warning)
- Also load root `.env` in local dev so `MONGO_URI` is available when running outside Docker

## Test

Play a ranked game → profile ELO and stats update correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed player rating and statistics persistence during gameplay to ensure accurate record-keeping.

* **Chores**
  * Enhanced environment configuration handling for improved compatibility across development and production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/turbo-leg/Durak/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->